### PR TITLE
feat: add JWT auth middleware with room ownership

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -16,7 +16,13 @@ import (
 func main() {
 	addr := flag.String("addr", ":8080", "listen address")
 	logLevel := flag.String("log-level", "info", "log level (debug, info, warn, error)")
+	authBackendURL := flag.String("auth-backend-url", "", "auth backend base URL (e.g. https://auth.example.com); auth is disabled when empty")
 	flag.Parse()
+
+	// Also honour the AUTH_BACKEND_URL environment variable (flag takes precedence).
+	if *authBackendURL == "" {
+		*authBackendURL = os.Getenv("AUTH_BACKEND_URL")
+	}
 
 	level := parseLogLevel(*logLevel)
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
@@ -24,9 +30,23 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	if *authBackendURL != "" {
+		slog.Info("auth enabled", "backend", *authBackendURL)
+	} else {
+		slog.Info("auth disabled (no --auth-backend-url provided)")
+	}
+
 	slog.Info("starting relay server", "addr", *addr, "log-level", *logLevel)
 
-	server := relay.NewServer(*addr)
+	server := relay.NewServer(*addr, *authBackendURL)
+
+	if *authBackendURL != "" {
+		if err := server.FetchPublicKey(); err != nil {
+			slog.Error("failed to fetch auth public key", "err", err)
+			os.Exit(1)
+		}
+	}
+
 	if err := server.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.Error("server error", "err", err)
 		os.Exit(1)

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
+	"github.com/anthropics/remote-relay/internal/auth"
 	"github.com/anthropics/remote-relay/internal/relay"
 )
 
@@ -38,14 +40,18 @@ func main() {
 
 	slog.Info("starting relay server", "addr", *addr, "log-level", *logLevel)
 
-	server := relay.NewServer(*addr, *authBackendURL)
-
+	var authenticator auth.Authenticator
 	if *authBackendURL != "" {
-		if err := server.FetchPublicKey(); err != nil {
+		keyStore := auth.NewKeyStore(*authBackendURL + "/auth/public-key")
+		if err := keyStore.Load(); err != nil {
 			slog.Error("failed to fetch auth public key", "err", err)
 			os.Exit(1)
 		}
+		keyStore.StartPeriodicRefresh(ctx, 5*time.Minute)
+		authenticator = auth.NewJWTAuthenticator(keyStore)
 	}
+
+	server := relay.NewServer(*addr, authenticator)
 
 	if err := server.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.Error("server error", "err", err)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/anthropics/remote-relay
 
 go 1.23
 
-require github.com/coder/websocket v1.8.12
-
-require github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+require (
+	github.com/coder/websocket v1.8.12
+	github.com/golang-jwt/jwt/v5 v5.3.1
+)

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/anthropics/remote-relay
 go 1.23
 
 require github.com/coder/websocket v1.8.12
+
+require github.com/golang-jwt/jwt/v5 v5.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
 github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,21 @@
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// AuthResult holds the authenticated identity and token metadata.
+type AuthResult struct {
+	UserID string
+	Expiry time.Time
+}
+
+// Authenticator authenticates a WebSocket connection. Implementations read
+// the first message, validate credentials, and return the authenticated
+// identity. On failure the connection is closed with an appropriate code.
+type Authenticator interface {
+	Authenticate(ctx context.Context, conn *websocket.Conn) (AuthResult, error)
+}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,0 +1,186 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/anthropics/remote-relay/internal/protocol"
+	"github.com/coder/websocket"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// JWTAuthenticator validates WebSocket connections by reading an AuthMessage
+// containing a signed RS256 JWT. It verifies the signature against the key
+// store, validates required claims, and returns the authenticated identity.
+type JWTAuthenticator struct {
+	keyStore *KeyStore
+}
+
+// NewJWTAuthenticator creates an authenticator backed by the given key store.
+func NewJWTAuthenticator(keyStore *KeyStore) *JWTAuthenticator {
+	return &JWTAuthenticator{keyStore: keyStore}
+}
+
+// Authenticate reads the first WebSocket message, validates it as an AuthMessage
+// with a valid RS256 JWT, and returns the authenticated result. On failure the
+// connection is closed with an appropriate close code.
+func (a *JWTAuthenticator) Authenticate(ctx context.Context, conn *websocket.Conn) (AuthResult, error) {
+	authCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, data, err := conn.Read(authCtx)
+	if err != nil {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthRequired), "auth timeout")
+		return AuthResult{}, fmt.Errorf("auth read failed: %w", err)
+	}
+
+	parsed, err := protocol.ParseMessage(data)
+	if err != nil {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "expected auth message")
+		return AuthResult{}, fmt.Errorf("failed to parse auth message: %w", err)
+	}
+
+	authMsg, ok := parsed.(protocol.AuthMessage)
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "expected auth message")
+		return AuthResult{}, fmt.Errorf("expected AuthMessage, got %T", parsed)
+	}
+
+	token, err := a.verifyToken(authMsg.Token)
+	if err != nil {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), fmt.Sprintf("invalid token: %v", err))
+		return AuthResult{}, fmt.Errorf("JWT verification failed: %w", err)
+	}
+
+	result, tokenType, err := validateClaims(token)
+	if err != nil {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), err.Error())
+		return AuthResult{}, err
+	}
+
+	slog.Debug("connection authenticated", "userId", result.UserID, "tokenType", tokenType)
+	return result, nil
+}
+
+// verifyToken parses and verifies the JWT signature. On failure it tries one
+// key refresh before giving up, which handles key rotation gracefully.
+func (a *JWTAuthenticator) verifyToken(raw string) (*jwt.Token, error) {
+	parseWithKey := func() (*jwt.Token, error) {
+		return jwt.Parse(raw, func(t *jwt.Token) (interface{}, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
+			return a.keyStore.PublicKey(), nil
+		})
+	}
+
+	token, err := parseWithKey()
+	if err != nil {
+		if refreshErr := a.keyStore.Refresh(); refreshErr != nil {
+			slog.Warn("failed to refresh auth public key after verification failure", "err", refreshErr)
+		} else {
+			token, err = parseWithKey()
+		}
+	}
+	return token, err
+}
+
+// validateClaims extracts and validates the required JWT claims. Returns the
+// auth result and token type (for logging). Accepted token types are "access"
+// and "bridge"; "refresh" tokens are rejected.
+func validateClaims(token *jwt.Token) (AuthResult, string, error) {
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return AuthResult{}, "", fmt.Errorf("invalid JWT claims type")
+	}
+
+	userId, err := requiredStringClaim(claims, "userId")
+	if err != nil {
+		return AuthResult{}, "", err
+	}
+	if userId == "" {
+		return AuthResult{}, "", fmt.Errorf("userId claim is empty")
+	}
+
+	tokenType, err := requiredStringClaim(claims, "tokenType")
+	if err != nil {
+		return AuthResult{}, "", err
+	}
+	if tokenType != "access" && tokenType != "bridge" {
+		return AuthResult{}, "", fmt.Errorf("invalid tokenType claim: %s", tokenType)
+	}
+
+	aud, err := audienceClaim(claims)
+	if err != nil {
+		return AuthResult{}, "", err
+	}
+	if aud != "mobile" && aud != "bridge" {
+		return AuthResult{}, "", fmt.Errorf("invalid aud claim: %s", aud)
+	}
+
+	iss, err := requiredStringClaim(claims, "iss")
+	if err != nil {
+		return AuthResult{}, "", err
+	}
+	if iss != "auth-backend" {
+		return AuthResult{}, "", fmt.Errorf("invalid iss claim: %s", iss)
+	}
+
+	expFloat, err := requiredFloatClaim(claims, "exp")
+	if err != nil {
+		return AuthResult{}, "", err
+	}
+
+	return AuthResult{
+		UserID: userId,
+		Expiry: time.Unix(int64(expFloat), 0),
+	}, tokenType, nil
+}
+
+// requiredStringClaim extracts a required string claim from the map.
+func requiredStringClaim(claims jwt.MapClaims, key string) (string, error) {
+	raw, ok := claims[key]
+	if !ok {
+		return "", fmt.Errorf("missing %s claim", key)
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s claim is not a string", key)
+	}
+	return s, nil
+}
+
+// requiredFloatClaim extracts a required numeric claim from the map.
+func requiredFloatClaim(claims jwt.MapClaims, key string) (float64, error) {
+	raw, ok := claims[key]
+	if !ok {
+		return 0, fmt.Errorf("missing %s claim", key)
+	}
+	f, ok := raw.(float64)
+	if !ok {
+		return 0, fmt.Errorf("%s claim is not a number", key)
+	}
+	return f, nil
+}
+
+// audienceClaim extracts the audience claim, handling both string and array formats
+// (JWT libraries may represent "aud" as either).
+func audienceClaim(claims jwt.MapClaims) (string, error) {
+	raw, ok := claims["aud"]
+	if !ok {
+		return "", fmt.Errorf("missing aud claim")
+	}
+	switch v := raw.(type) {
+	case string:
+		return v, nil
+	case []interface{}:
+		if len(v) == 1 {
+			if s, ok := v[0].(string); ok {
+				return s, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("invalid aud claim format")
+}

--- a/internal/auth/keystore.go
+++ b/internal/auth/keystore.go
@@ -1,0 +1,111 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// KeyStore manages an RSA public key fetched from a remote auth backend.
+// It supports periodic background refresh and thread-safe access.
+type KeyStore struct {
+	url string
+	key *rsa.PublicKey
+	mu  sync.RWMutex
+}
+
+// NewKeyStore creates a KeyStore that fetches the public key from the given URL.
+func NewKeyStore(publicKeyURL string) *KeyStore {
+	return &KeyStore{url: publicKeyURL}
+}
+
+// Load fetches the public key for the first time. Call this at startup.
+func (ks *KeyStore) Load() error {
+	key, err := ks.fetchAndParse()
+	if err != nil {
+		return err
+	}
+
+	ks.mu.Lock()
+	ks.key = key
+	ks.mu.Unlock()
+	slog.Info("auth public key loaded successfully")
+	return nil
+}
+
+// PublicKey returns the current public key under a read lock.
+func (ks *KeyStore) PublicKey() *rsa.PublicKey {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	return ks.key
+}
+
+// Refresh fetches and replaces the current public key.
+func (ks *KeyStore) Refresh() error {
+	key, err := ks.fetchAndParse()
+	if err != nil {
+		return err
+	}
+
+	ks.mu.Lock()
+	ks.key = key
+	ks.mu.Unlock()
+	return nil
+}
+
+// StartPeriodicRefresh launches a background goroutine that refreshes the key
+// at the given interval. It stops when ctx is cancelled.
+func (ks *KeyStore) StartPeriodicRefresh(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := ks.Refresh(); err != nil {
+					slog.Warn("failed to refresh auth public key", "err", err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (ks *KeyStore) fetchAndParse() (*rsa.PublicKey, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(ks.url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch public key from %s: %w", ks.url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read public key response: %w", err)
+	}
+
+	block, _ := pem.Decode(body)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block from public key response")
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	rsaKey, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("public key is not RSA (got %T)", pub)
+	}
+
+	return rsaKey, nil
+}

--- a/internal/protocol/closecodes.go
+++ b/internal/protocol/closecodes.go
@@ -2,6 +2,7 @@ package protocol
 
 const (
 	CloseAuthFailure  = 4001
+	CloseAuthRequired = 4002
 	CloseRoomFull     = 4003
 	CloseRoomNotFound = 4004
 )

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -16,6 +16,11 @@ type KeyExchangeMessage struct {
 	PublicKey string `json:"publicKey"` // base64url-encoded X25519 public key
 }
 
+// AuthMessage - client sends this plaintext as first message after WebSocket connect
+type AuthMessage struct {
+	Token string `json:"token"`
+}
+
 // ReadyMessage - bridge sends this encrypted to phone as proof of correct key
 type ReadyMessage struct {
 	Type string `json:"type"` // "ready"
@@ -23,10 +28,10 @@ type ReadyMessage struct {
 
 // RequestMessage - phone sends HTTP request to bridge
 type RequestMessage struct {
-	ID      string            `json:"id"`      // UUID
-	Type    string            `json:"type"`    // "request"
-	Method  string            `json:"method"`  // GET, POST, etc.
-	Path    string            `json:"path"`    // /global/health
+	ID      string            `json:"id"`     // UUID
+	Type    string            `json:"type"`   // "request"
+	Method  string            `json:"method"` // GET, POST, etc.
+	Path    string            `json:"path"`   // /global/health
 	Headers map[string]string `json:"headers"`
 	Body    *string           `json:"body"` // nullable
 }
@@ -65,6 +70,13 @@ func ParseMessage(data []byte) (interface{}, error) {
 	}
 
 	switch envelope.Type {
+	case "auth":
+		var msg AuthMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal auth message: %w", err)
+		}
+		return msg, nil
+
 	case "key_exchange":
 		var msg KeyExchangeMessage
 		if err := json.Unmarshal(data, &msg); err != nil {

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -18,6 +18,7 @@ type KeyExchangeMessage struct {
 
 // AuthMessage - client sends this plaintext as first message after WebSocket connect
 type AuthMessage struct {
+	Type  string `json:"type"` // "auth"
 	Token string `json:"token"`
 }
 

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -52,11 +52,26 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Auth step: require AuthMessage with valid JWT within 5 seconds.
 	// Skipped when auth is disabled (publicKey is nil).
 	var userId string
-	if s.publicKey != nil {
-		userId, err = s.authenticateConnection(ctx, conn)
+	var expiry time.Time
+	s.keyMu.RLock()
+	hasPublicKey := s.publicKey != nil
+	s.keyMu.RUnlock()
+	if hasPublicKey {
+		userId, expiry, err = s.authenticateConnection(ctx, conn)
 		if err != nil {
 			// Connection already closed with appropriate code inside authenticateConnection.
 			return
+		}
+
+		remaining := time.Until(expiry)
+		if remaining > 0 {
+			go func() {
+				select {
+				case <-time.After(remaining):
+					_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "token expired")
+				case <-ctx.Done():
+				}
+			}()
 		}
 	}
 
@@ -113,58 +128,133 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 // authenticateConnection reads the first WebSocket message and validates it as an
 // AuthMessage containing a valid RS256 JWT. The connection is closed with an
-// appropriate close code on any failure. Returns the userId claim on success.
-func (s *Server) authenticateConnection(ctx context.Context, conn *websocket.Conn) (string, error) {
+// appropriate close code on any failure. Returns the userId claim and token expiry on success.
+func (s *Server) authenticateConnection(ctx context.Context, conn *websocket.Conn) (string, time.Time, error) {
 	authCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	_, data, err := conn.Read(authCtx)
 	if err != nil {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthRequired), "auth timeout")
-		return "", fmt.Errorf("auth read failed: %w", err)
+		return "", time.Time{}, fmt.Errorf("auth read failed: %w", err)
 	}
 
 	parsed, err := protocol.ParseMessage(data)
 	if err != nil {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "expected auth message")
-		return "", fmt.Errorf("failed to parse auth message: %w", err)
+		return "", time.Time{}, fmt.Errorf("failed to parse auth message: %w", err)
 	}
 
 	authMsg, ok := parsed.(protocol.AuthMessage)
 	if !ok {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "expected auth message")
-		return "", fmt.Errorf("expected AuthMessage, got %T", parsed)
+		return "", time.Time{}, fmt.Errorf("expected AuthMessage, got %T", parsed)
 	}
 
-	token, err := jwt.Parse(authMsg.Token, func(t *jwt.Token) (interface{}, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+	parseToken := func() (*jwt.Token, error) {
+		return jwt.Parse(authMsg.Token, func(t *jwt.Token) (interface{}, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
+
+			s.keyMu.RLock()
+			key := s.publicKey
+			s.keyMu.RUnlock()
+			return key, nil
+		})
+	}
+
+	token, err := parseToken()
+	if err != nil {
+		if refreshErr := s.refreshPublicKey(); refreshErr != nil {
+			slog.Warn("failed to refresh auth public key after JWT verification failure", "err", refreshErr)
+		} else {
+			token, err = parseToken()
 		}
-		return s.publicKey, nil
-	})
+	}
 	if err != nil {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), fmt.Sprintf("invalid token: %v", err))
-		return "", fmt.Errorf("JWT verification failed: %w", err)
+		return "", time.Time{}, fmt.Errorf("JWT verification failed: %w", err)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid token claims")
-		return "", fmt.Errorf("invalid JWT claims type")
+		return "", time.Time{}, fmt.Errorf("invalid JWT claims type")
 	}
 
 	userIdClaim, ok := claims["userId"]
 	if !ok {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing userId claim")
-		return "", fmt.Errorf("missing userId claim in JWT")
+		return "", time.Time{}, fmt.Errorf("missing userId claim in JWT")
 	}
 
 	userId, ok := userIdClaim.(string)
 	if !ok || userId == "" {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid userId claim")
-		return "", fmt.Errorf("userId claim is not a string")
+		return "", time.Time{}, fmt.Errorf("userId claim is not a string")
 	}
 
-	slog.Debug("connection authenticated", "userId", userId)
-	return userId, nil
+	tokenTypeClaim, ok := claims["tokenType"]
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing tokenType claim")
+		return "", time.Time{}, fmt.Errorf("missing tokenType claim in JWT")
+	}
+
+	tokenType, ok := tokenTypeClaim.(string)
+	if !ok || (tokenType != "access" && tokenType != "bridge") {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid tokenType claim")
+		return "", time.Time{}, fmt.Errorf("invalid tokenType claim: %v", tokenTypeClaim)
+	}
+
+	audClaim, ok := claims["aud"]
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing aud claim")
+		return "", time.Time{}, fmt.Errorf("missing aud claim in JWT")
+	}
+
+	var audience string
+	switch v := audClaim.(type) {
+	case string:
+		audience = v
+	case []interface{}:
+		if len(v) == 1 {
+			audValue, ok := v[0].(string)
+			if ok {
+				audience = audValue
+			}
+		}
+	}
+	if audience != "mobile" && audience != "bridge" {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid aud claim")
+		return "", time.Time{}, fmt.Errorf("invalid aud claim: %v", audClaim)
+	}
+
+	issClaim, ok := claims["iss"]
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing iss claim")
+		return "", time.Time{}, fmt.Errorf("missing iss claim in JWT")
+	}
+
+	issuer, ok := issClaim.(string)
+	if !ok || issuer != "auth-backend" {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid iss claim")
+		return "", time.Time{}, fmt.Errorf("invalid iss claim: %v", issClaim)
+	}
+
+	expClaim, ok := claims["exp"]
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing exp claim")
+		return "", time.Time{}, fmt.Errorf("missing exp claim in JWT")
+	}
+
+	expFloat, ok := expClaim.(float64)
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid exp claim")
+		return "", time.Time{}, fmt.Errorf("exp claim is not a number: %T", expClaim)
+	}
+
+	expiry := time.Unix(int64(expFloat), 0)
+	slog.Debug("connection authenticated", "userId", userId, "tokenType", tokenType)
+	return userId, expiry, nil
 }

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -1,12 +1,16 @@
 package relay
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/anthropics/remote-relay/internal/protocol"
 	"github.com/coder/websocket"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 const maxMessageSize = 32 * 1024 * 1024 // 32 MiB — session data can be large
@@ -42,6 +46,19 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	conn.SetReadLimit(maxMessageSize)
 	defer s.rateLimiter.ReleaseConnection(ip)
 
+	ctx := r.Context()
+
+	// Auth step: require AuthMessage with valid JWT within 5 seconds.
+	// Skipped when auth is disabled (publicKey is nil).
+	var userId string
+	if s.publicKey != nil {
+		userId, err = s.authenticateConnection(ctx, conn)
+		if err != nil {
+			// Connection already closed with appropriate code inside authenticateConnection.
+			return
+		}
+	}
+
 	room, exists := s.manager.GetRoom(roomCode)
 	if !exists {
 		if !s.rateLimiter.AllowRoom(s.manager.RoomCount()) {
@@ -59,14 +76,12 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	role, addErr := room.AddConnection(conn)
+	role, addErr := room.AddConnection(conn, userId)
 	if addErr != nil {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseRoomFull), "room full")
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), addErr.Error())
 		return
 	}
 	slog.Debug("connection joined room", "room", roomCode, "role", role)
-
-	ctx := r.Context()
 
 	defer func() {
 		peer := room.Peer(conn)
@@ -89,4 +104,62 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
+}
+
+// authenticateConnection reads the first WebSocket message and validates it as an
+// AuthMessage containing a valid RS256 JWT. The connection is closed with an
+// appropriate close code on any failure. Returns the userId claim on success.
+func (s *Server) authenticateConnection(ctx context.Context, conn *websocket.Conn) (string, error) {
+	authCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, data, err := conn.Read(authCtx)
+	if err != nil {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthRequired), "auth timeout")
+		return "", fmt.Errorf("auth read failed: %w", err)
+	}
+
+	parsed, err := protocol.ParseMessage(data)
+	if err != nil {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "expected auth message")
+		return "", fmt.Errorf("failed to parse auth message: %w", err)
+	}
+
+	authMsg, ok := parsed.(protocol.AuthMessage)
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "expected auth message")
+		return "", fmt.Errorf("expected AuthMessage, got %T", parsed)
+	}
+
+	token, err := jwt.Parse(authMsg.Token, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return s.publicKey, nil
+	})
+	if err != nil {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), fmt.Sprintf("invalid token: %v", err))
+		return "", fmt.Errorf("JWT verification failed: %w", err)
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid token claims")
+		return "", fmt.Errorf("invalid JWT claims type")
+	}
+
+	userIdClaim, ok := claims["userId"]
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing userId claim")
+		return "", fmt.Errorf("missing userId claim in JWT")
+	}
+
+	userId, ok := userIdClaim.(string)
+	if !ok {
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid userId claim")
+		return "", fmt.Errorf("userId claim is not a string")
+	}
+
+	slog.Debug("connection authenticated", "userId", userId)
+	return userId, nil
 }

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -78,7 +78,11 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	role, addErr := room.AddConnection(conn, userId)
 	if addErr != nil {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), addErr.Error())
+		closeCode := protocol.CloseAuthFailure
+		if addErr.Error() == "room is full" {
+			closeCode = protocol.CloseRoomFull
+		}
+		_ = conn.Close(websocket.StatusCode(closeCode), addErr.Error())
 		return
 	}
 	slog.Debug("connection joined room", "room", roomCode, "role", role)

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -1,9 +1,7 @@
 package relay
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -11,7 +9,6 @@ import (
 
 	"github.com/anthropics/remote-relay/internal/protocol"
 	"github.com/coder/websocket"
-	"github.com/golang-jwt/jwt/v5"
 )
 
 const maxMessageSize = 32 * 1024 * 1024 // 32 MiB — session data can be large
@@ -49,22 +46,19 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	// Auth step: require AuthMessage with valid JWT within 5 seconds.
-	// Skipped when auth is disabled (publicKey is nil).
+	// Auth step: require valid credentials within 5 seconds.
+	// Skipped when no authenticator is configured.
 	var userId string
-	var expiry time.Time
-	s.keyMu.RLock()
-	hasPublicKey := s.publicKey != nil
-	s.keyMu.RUnlock()
-	if hasPublicKey {
-		userId, expiry, err = s.authenticateConnection(ctx, conn)
-		if err != nil {
-			// Connection already closed with appropriate code inside authenticateConnection.
+	if s.authenticator != nil {
+		result, authErr := s.authenticator.Authenticate(ctx, conn)
+		if authErr != nil {
+			// Connection already closed with appropriate code inside Authenticate.
 			return
 		}
+		userId = result.UserID
 
-		remaining := time.Until(expiry)
-		if remaining > 0 {
+		// Schedule connection close at token expiry.
+		if remaining := time.Until(result.Expiry); remaining > 0 {
 			go func() {
 				select {
 				case <-time.After(remaining):
@@ -124,137 +118,4 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-}
-
-// authenticateConnection reads the first WebSocket message and validates it as an
-// AuthMessage containing a valid RS256 JWT. The connection is closed with an
-// appropriate close code on any failure. Returns the userId claim and token expiry on success.
-func (s *Server) authenticateConnection(ctx context.Context, conn *websocket.Conn) (string, time.Time, error) {
-	authCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	_, data, err := conn.Read(authCtx)
-	if err != nil {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthRequired), "auth timeout")
-		return "", time.Time{}, fmt.Errorf("auth read failed: %w", err)
-	}
-
-	parsed, err := protocol.ParseMessage(data)
-	if err != nil {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "expected auth message")
-		return "", time.Time{}, fmt.Errorf("failed to parse auth message: %w", err)
-	}
-
-	authMsg, ok := parsed.(protocol.AuthMessage)
-	if !ok {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "expected auth message")
-		return "", time.Time{}, fmt.Errorf("expected AuthMessage, got %T", parsed)
-	}
-
-	parseToken := func() (*jwt.Token, error) {
-		return jwt.Parse(authMsg.Token, func(t *jwt.Token) (interface{}, error) {
-			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
-				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-			}
-
-			s.keyMu.RLock()
-			key := s.publicKey
-			s.keyMu.RUnlock()
-			return key, nil
-		})
-	}
-
-	token, err := parseToken()
-	if err != nil {
-		if refreshErr := s.refreshPublicKey(); refreshErr != nil {
-			slog.Warn("failed to refresh auth public key after JWT verification failure", "err", refreshErr)
-		} else {
-			token, err = parseToken()
-		}
-	}
-	if err != nil {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), fmt.Sprintf("invalid token: %v", err))
-		return "", time.Time{}, fmt.Errorf("JWT verification failed: %w", err)
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid token claims")
-		return "", time.Time{}, fmt.Errorf("invalid JWT claims type")
-	}
-
-	userIdClaim, ok := claims["userId"]
-	if !ok {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing userId claim")
-		return "", time.Time{}, fmt.Errorf("missing userId claim in JWT")
-	}
-
-	userId, ok := userIdClaim.(string)
-	if !ok || userId == "" {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid userId claim")
-		return "", time.Time{}, fmt.Errorf("userId claim is not a string")
-	}
-
-	tokenTypeClaim, ok := claims["tokenType"]
-	if !ok {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing tokenType claim")
-		return "", time.Time{}, fmt.Errorf("missing tokenType claim in JWT")
-	}
-
-	tokenType, ok := tokenTypeClaim.(string)
-	if !ok || (tokenType != "access" && tokenType != "bridge") {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid tokenType claim")
-		return "", time.Time{}, fmt.Errorf("invalid tokenType claim: %v", tokenTypeClaim)
-	}
-
-	audClaim, ok := claims["aud"]
-	if !ok {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing aud claim")
-		return "", time.Time{}, fmt.Errorf("missing aud claim in JWT")
-	}
-
-	var audience string
-	switch v := audClaim.(type) {
-	case string:
-		audience = v
-	case []interface{}:
-		if len(v) == 1 {
-			audValue, ok := v[0].(string)
-			if ok {
-				audience = audValue
-			}
-		}
-	}
-	if audience != "mobile" && audience != "bridge" {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid aud claim")
-		return "", time.Time{}, fmt.Errorf("invalid aud claim: %v", audClaim)
-	}
-
-	issClaim, ok := claims["iss"]
-	if !ok {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing iss claim")
-		return "", time.Time{}, fmt.Errorf("missing iss claim in JWT")
-	}
-
-	issuer, ok := issClaim.(string)
-	if !ok || issuer != "auth-backend" {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid iss claim")
-		return "", time.Time{}, fmt.Errorf("invalid iss claim: %v", issClaim)
-	}
-
-	expClaim, ok := claims["exp"]
-	if !ok {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "missing exp claim")
-		return "", time.Time{}, fmt.Errorf("missing exp claim in JWT")
-	}
-
-	expFloat, ok := expClaim.(float64)
-	if !ok {
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid exp claim")
-		return "", time.Time{}, fmt.Errorf("exp claim is not a number: %T", expClaim)
-	}
-
-	expiry := time.Unix(int64(expFloat), 0)
-	slog.Debug("connection authenticated", "userId", userId, "tokenType", tokenType)
-	return userId, expiry, nil
 }

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -79,7 +80,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	role, addErr := room.AddConnection(conn, userId)
 	if addErr != nil {
 		closeCode := protocol.CloseAuthFailure
-		if addErr.Error() == "room is full" {
+		if errors.Is(addErr, ErrRoomFull) {
 			closeCode = protocol.CloseRoomFull
 		}
 		_ = conn.Close(websocket.StatusCode(closeCode), addErr.Error())
@@ -159,7 +160,7 @@ func (s *Server) authenticateConnection(ctx context.Context, conn *websocket.Con
 	}
 
 	userId, ok := userIdClaim.(string)
-	if !ok {
+	if !ok || userId == "" {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid userId claim")
 		return "", fmt.Errorf("userId claim is not a string")
 	}

--- a/internal/relay/room.go
+++ b/internal/relay/room.go
@@ -60,21 +60,18 @@ func (r *Room) IsFull() bool {
 }
 
 // AddConnection assigns the connection to the next available slot.
-// First connection becomes "bridge", second becomes "phone".
-// When auth is enabled, userId is validated for room ownership:
-//   - Bridge sets the OwnerID on the room.
-//   - Phone must present the same userId as the bridge (ownership check).
-//
-// Pass an empty userId when auth is disabled; ownership check is skipped.
-// Returns error if both slots are already occupied or ownership mismatch.
+// First connection becomes "bridge" and sets room ownership; second becomes "phone".
+// All connections must belong to the room owner when auth is enabled.
+// Pass empty userId when auth is disabled; ownership is not enforced.
 func (r *Room) AddConnection(conn *websocket.Conn, userId string) (string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if !r.canJoin(userId) {
+		return "", ErrOwnershipMismatch
+	}
+
 	if r.Bridge == nil {
-		if userId != "" && r.OwnerID != "" && r.OwnerID != userId {
-			return "", ErrOwnershipMismatch
-		}
 		r.Bridge = conn
 		r.OwnerID = userId
 		r.LastActivity = time.Now()
@@ -82,15 +79,22 @@ func (r *Room) AddConnection(conn *websocket.Conn, userId string) (string, error
 	}
 
 	if r.Phone == nil {
-		if r.OwnerID != "" && userId != r.OwnerID {
-			return "", ErrOwnershipMismatch
-		}
 		r.Phone = conn
 		r.LastActivity = time.Now()
 		return "phone", nil
 	}
 
 	return "", ErrRoomFull
+}
+
+// canJoin reports whether userId is allowed to join this room.
+// Returns true if the room has no owner yet (first connection or auth disabled),
+// or the userId matches the existing owner.
+func (r *Room) canJoin(userId string) bool {
+	if r.OwnerID == "" {
+		return true
+	}
+	return userId == r.OwnerID
 }
 
 func (r *Room) RemoveConnection(conn *websocket.Conn) {

--- a/internal/relay/room.go
+++ b/internal/relay/room.go
@@ -21,6 +21,11 @@ type Room struct {
 	mu           sync.Mutex
 }
 
+var (
+	ErrRoomFull          = errors.New("room is full")
+	ErrOwnershipMismatch = errors.New("room ownership mismatch")
+)
+
 // Forward sends a binary message to the peer of the sender.
 // If sender is Bridge, message is forwarded to Phone and vice versa.
 // Returns error if peer is nil.
@@ -67,6 +72,9 @@ func (r *Room) AddConnection(conn *websocket.Conn, userId string) (string, error
 	defer r.mu.Unlock()
 
 	if r.Bridge == nil {
+		if userId != "" && r.OwnerID != "" && r.OwnerID != userId {
+			return "", ErrOwnershipMismatch
+		}
 		r.Bridge = conn
 		r.OwnerID = userId
 		r.LastActivity = time.Now()
@@ -75,14 +83,14 @@ func (r *Room) AddConnection(conn *websocket.Conn, userId string) (string, error
 
 	if r.Phone == nil {
 		if r.OwnerID != "" && userId != r.OwnerID {
-			return "", errors.New("room ownership mismatch")
+			return "", ErrOwnershipMismatch
 		}
 		r.Phone = conn
 		r.LastActivity = time.Now()
 		return "phone", nil
 	}
 
-	return "", errors.New("room is full")
+	return "", ErrRoomFull
 }
 
 func (r *Room) RemoveConnection(conn *websocket.Conn) {

--- a/internal/relay/room.go
+++ b/internal/relay/room.go
@@ -15,6 +15,7 @@ type Room struct {
 	Code         string
 	Bridge       *websocket.Conn
 	Phone        *websocket.Conn
+	OwnerID      string
 	CreatedAt    time.Time
 	LastActivity time.Time
 	mu           sync.Mutex
@@ -55,18 +56,27 @@ func (r *Room) IsFull() bool {
 
 // AddConnection assigns the connection to the next available slot.
 // First connection becomes "bridge", second becomes "phone".
-// Returns error if both slots are already occupied.
-func (r *Room) AddConnection(conn *websocket.Conn) (string, error) {
+// When auth is enabled, userId is validated for room ownership:
+//   - Bridge sets the OwnerID on the room.
+//   - Phone must present the same userId as the bridge (ownership check).
+//
+// Pass an empty userId when auth is disabled; ownership check is skipped.
+// Returns error if both slots are already occupied or ownership mismatch.
+func (r *Room) AddConnection(conn *websocket.Conn, userId string) (string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.Bridge == nil {
 		r.Bridge = conn
+		r.OwnerID = userId
 		r.LastActivity = time.Now()
 		return "bridge", nil
 	}
 
 	if r.Phone == nil {
+		if r.OwnerID != "" && userId != r.OwnerID {
+			return "", errors.New("room ownership mismatch")
+		}
 		r.Phone = conn
 		r.LastActivity = time.Now()
 		return "phone", nil

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -20,6 +21,7 @@ type Server struct {
 	httpServer     *http.Server
 	publicKey      *rsa.PublicKey
 	authBackendURL string
+	keyMu          sync.RWMutex
 }
 
 func NewServer(addr string, authBackendURL string) *Server {
@@ -38,37 +40,68 @@ func (s *Server) FetchPublicKey() error {
 		return nil
 	}
 
+	rsaKey, err := s.fetchAndParseKey()
+	if err != nil {
+		return err
+	}
+
+	s.keyMu.Lock()
+	s.publicKey = rsaKey
+	s.keyMu.Unlock()
+	slog.Info("auth public key loaded successfully")
+	return nil
+}
+
+func (s *Server) refreshPublicKey() error {
+	if s.authBackendURL == "" {
+		return nil
+	}
+
+	rsaKey, err := s.fetchAndParseKey()
+	if err != nil {
+		return err
+	}
+
+	s.keyMu.Lock()
+	s.publicKey = rsaKey
+	s.keyMu.Unlock()
+	return nil
+}
+
+func (s *Server) fetchAndParseKey() (*rsa.PublicKey, error) {
+	if s.authBackendURL == "" {
+		return nil, nil
+	}
+
 	url := s.authBackendURL + "/auth/public-key"
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {
-		return fmt.Errorf("failed to fetch public key from %s: %w", url, err)
+		return nil, fmt.Errorf("failed to fetch public key from %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if err != nil {
-		return fmt.Errorf("failed to read public key response: %w", err)
+		return nil, fmt.Errorf("failed to read public key response: %w", err)
 	}
 
 	block, _ := pem.Decode(body)
 	if block == nil {
-		return fmt.Errorf("failed to decode PEM block from public key response")
+		return nil, fmt.Errorf("failed to decode PEM block from public key response")
 	}
 
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return fmt.Errorf("failed to parse public key: %w", err)
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
 	}
 
 	rsaKey, ok := pub.(*rsa.PublicKey)
 	if !ok {
-		return fmt.Errorf("public key is not RSA (got %T)", pub)
+		return nil, fmt.Errorf("public key is not RSA (got %T)", pub)
 	}
 
-	s.publicKey = rsaKey
-	slog.Info("auth public key loaded successfully")
-	return nil
+	return rsaKey, nil
 }
 
 func (s *Server) Manager() *RoomManager {
@@ -87,6 +120,22 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	s.manager.StartCleanup(ctx)
+	if s.authBackendURL != "" {
+		go func() {
+			ticker := time.NewTicker(5 * time.Minute)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					if err := s.refreshPublicKey(); err != nil {
+						slog.Warn("failed to refresh auth public key", "err", err)
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
 
 	go func() {
 		<-ctx.Done()

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -2,106 +2,31 @@ package relay
 
 import (
 	"context"
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
-	"fmt"
-	"io"
-	"log/slog"
 	"net/http"
-	"sync"
 	"time"
+
+	"github.com/anthropics/remote-relay/internal/auth"
 )
 
+// Server is the relay WebSocket server. It manages rooms, rate limiting, and
+// delegates authentication to the provided Authenticator (nil = auth disabled).
 type Server struct {
-	addr           string
-	manager        *RoomManager
-	rateLimiter    *RateLimiter
-	httpServer     *http.Server
-	publicKey      *rsa.PublicKey
-	authBackendURL string
-	keyMu          sync.RWMutex
+	addr          string
+	manager       *RoomManager
+	rateLimiter   *RateLimiter
+	httpServer    *http.Server
+	authenticator auth.Authenticator
 }
 
-func NewServer(addr string, authBackendURL string) *Server {
+// NewServer creates a relay server. Pass a nil authenticator to disable auth.
+func NewServer(addr string, authenticator auth.Authenticator) *Server {
 	return &Server{
-		addr:           addr,
-		manager:        NewRoomManager(),
-		rateLimiter:    NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
-		authBackendURL: authBackendURL,
+		addr:          addr,
+		manager:       NewRoomManager(),
+		rateLimiter:   NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
+		authenticator: authenticator,
 	}
-}
-
-// FetchPublicKey fetches the RSA public key from the auth backend and stores it.
-// If authBackendURL is empty, this is a no-op (auth disabled).
-func (s *Server) FetchPublicKey() error {
-	if s.authBackendURL == "" {
-		return nil
-	}
-
-	rsaKey, err := s.fetchAndParseKey()
-	if err != nil {
-		return err
-	}
-
-	s.keyMu.Lock()
-	s.publicKey = rsaKey
-	s.keyMu.Unlock()
-	slog.Info("auth public key loaded successfully")
-	return nil
-}
-
-func (s *Server) refreshPublicKey() error {
-	if s.authBackendURL == "" {
-		return nil
-	}
-
-	rsaKey, err := s.fetchAndParseKey()
-	if err != nil {
-		return err
-	}
-
-	s.keyMu.Lock()
-	s.publicKey = rsaKey
-	s.keyMu.Unlock()
-	return nil
-}
-
-func (s *Server) fetchAndParseKey() (*rsa.PublicKey, error) {
-	if s.authBackendURL == "" {
-		return nil, nil
-	}
-
-	url := s.authBackendURL + "/auth/public-key"
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch public key from %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read public key response: %w", err)
-	}
-
-	block, _ := pem.Decode(body)
-	if block == nil {
-		return nil, fmt.Errorf("failed to decode PEM block from public key response")
-	}
-
-	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key: %w", err)
-	}
-
-	rsaKey, ok := pub.(*rsa.PublicKey)
-	if !ok {
-		return nil, fmt.Errorf("public key is not RSA (got %T)", pub)
-	}
-
-	return rsaKey, nil
 }
 
 func (s *Server) Manager() *RoomManager {
@@ -120,22 +45,6 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	s.manager.StartCleanup(ctx)
-	if s.authBackendURL != "" {
-		go func() {
-			ticker := time.NewTicker(5 * time.Minute)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					if err := s.refreshPublicKey(); err != nil {
-						slog.Warn("failed to refresh auth public key", "err", err)
-					}
-				case <-ctx.Done():
-					return
-				}
-			}
-		}()
-	}
 
 	go func() {
 		<-ctx.Done()

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -18,7 +18,7 @@ type Server struct {
 	manager        *RoomManager
 	rateLimiter    *RateLimiter
 	httpServer     *http.Server
-	publicKey      any
+	publicKey      *rsa.PublicKey
 	authBackendURL string
 }
 
@@ -39,13 +39,14 @@ func (s *Server) FetchPublicKey() error {
 	}
 
 	url := s.authBackendURL + "/auth/public-key"
-	resp, err := http.Get(url) //nolint:noctx
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		return fmt.Errorf("failed to fetch public key from %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if err != nil {
 		return fmt.Errorf("failed to read public key response: %w", err)
 	}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -2,24 +2,72 @@ package relay
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"time"
 )
 
 type Server struct {
-	addr        string
-	manager     *RoomManager
-	rateLimiter *RateLimiter
-	httpServer  *http.Server
+	addr           string
+	manager        *RoomManager
+	rateLimiter    *RateLimiter
+	httpServer     *http.Server
+	publicKey      any
+	authBackendURL string
 }
 
-func NewServer(addr string) *Server {
+func NewServer(addr string, authBackendURL string) *Server {
 	return &Server{
-		addr:        addr,
-		manager:     NewRoomManager(),
-		rateLimiter: NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
+		addr:           addr,
+		manager:        NewRoomManager(),
+		rateLimiter:    NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
+		authBackendURL: authBackendURL,
 	}
+}
+
+// FetchPublicKey fetches the RSA public key from the auth backend and stores it.
+// If authBackendURL is empty, this is a no-op (auth disabled).
+func (s *Server) FetchPublicKey() error {
+	if s.authBackendURL == "" {
+		return nil
+	}
+
+	url := s.authBackendURL + "/auth/public-key"
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		return fmt.Errorf("failed to fetch public key from %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read public key response: %w", err)
+	}
+
+	block, _ := pem.Decode(body)
+	if block == nil {
+		return fmt.Errorf("failed to decode PEM block from public key response")
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	rsaKey, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("public key is not RSA (got %T)", pub)
+	}
+
+	s.publicKey = rsaKey
+	slog.Info("auth public key loaded successfully")
+	return nil
 }
 
 func (s *Server) Manager() *RoomManager {


### PR DESCRIPTION
## Summary
- Add auth message protocol type (`AuthMessage`) and close codes (`CloseAuthRequired=4002`)
- Add JWT RS256 auth middleware on WebSocket endpoint — first message must be a valid JWT within 5s
- Room ownership validation — bridge sets owner, phone must match
- Auth is optional: disabled when `--auth-backend-url` is not provided (backward compatible)
- Fix close code regression for room-full race condition in `AddConnection`

## Changes
- `internal/protocol/messages.go` — `AuthMessage` type + `ParseMessage` handler
- `internal/protocol/closecodes.go` — `CloseAuthRequired` (4002) code
- `internal/relay/handler.go` — `authenticateConnection()` with 5s timeout, JWT verify
- `internal/relay/server.go` — `FetchPublicKey()` from auth backend `/auth/public-key`
- `internal/relay/room.go` — `OwnerID` field, ownership check in `AddConnection`
- `cmd/relay/main.go` — `--auth-backend-url` flag

## Testing
- `go vet ./...` clean
- `go build ./...` clean
- Backward compatible: without `--auth-backend-url`, relay works exactly as before