### PR TITLE
fix: add WebSocket ping/pong keepalive

### DIFF
--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -111,7 +111,10 @@ func startPingLoop(ctx context.Context, cancel context.CancelFunc, conn *websock
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := conn.Ping(ctx); err != nil {
+				pingCtx, cancelPing := context.WithTimeout(ctx, pingInterval/2)
+				err := conn.Ping(pingCtx)
+				cancelPing()
+				if err != nil {
 					cancel()
 					return
 				}

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -17,6 +17,7 @@ import (
 const (
 	maxMessageSize      = 32 * 1024 * 1024 // 32 MiB — session data can be large
 	maxPhonesPerAccount = 5
+	pingInterval        = 30 * time.Second
 )
 
 var (
@@ -101,6 +102,24 @@ func readAndValidateAuth(ctx context.Context, conn *websocket.Conn, jwtAuth *aut
 	return authMsg, result.UserID, true
 }
 
+func startPingLoop(ctx context.Context, cancel context.CancelFunc, conn *websocket.Conn) {
+	go func() {
+		ticker := time.NewTicker(pingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := conn.Ping(ctx); err != nil {
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+}
+
 func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID string) {
 	group.mu.Lock()
 	oldBridge := group.Bridge
@@ -108,6 +127,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 	newConn := &Connection{Conn: conn, ConnID: 0, Cancel: connCancel}
 	group.Bridge = newConn
 	group.mu.Unlock()
+	startPingLoop(connCtx, connCancel, conn)
 
 	phones := group.AllPhones()
 
@@ -198,6 +218,8 @@ func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup,
 		group.mu.Unlock()
 		break
 	}
+
+	startPingLoop(connCtx, connCancel, conn)
 
 	if bridgeConn != nil {
 		phoneConnMsg, err := json.Marshal(protocol.PhoneConnectedMessage{Type: protocol.TypePhoneConnected, ConnID: connID})


### PR DESCRIPTION
## Summary
- Adds periodic WebSocket ping (30s) to all relay connections (bridge + phone)
- Prevents Cloudflare from killing idle WebSocket connections (~100s timeout)
- Ping failure triggers connection cleanup via context cancellation