### PR TITLE
feat: notify auth server on bridge connect/disconnect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ RELAY_ADDR=:8080
 # Log level: debug, info, warn, error
 # Default: info
 LOG_LEVEL=info
+
+# Shared secret for relay -> auth webhook calls
+RELAY_WEBHOOK_SECRET=

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sesori-ai/sesori_relay_server/internal/auth"
+	"github.com/sesori-ai/sesori_relay_server/internal/notifications"
 	"github.com/sesori-ai/sesori_relay_server/internal/relay"
 )
 
@@ -19,11 +20,15 @@ func main() {
 	addr := flag.String("addr", ":8080", "listen address")
 	logLevel := flag.String("log-level", "info", "log level (debug, info, warn, error)")
 	authBackendURL := flag.String("auth-backend-url", "", "auth backend base URL (e.g. https://auth.example.com); auth is disabled when empty")
+	relayWebhookSecret := flag.String("relay-webhook-secret", "", "shared secret for auth server webhook")
 	flag.Parse()
 
 	// Also honour the AUTH_BACKEND_URL environment variable (flag takes precedence).
 	if *authBackendURL == "" {
 		*authBackendURL = os.Getenv("AUTH_BACKEND_URL")
+	}
+	if *relayWebhookSecret == "" {
+		*relayWebhookSecret = os.Getenv("RELAY_WEBHOOK_SECRET")
 	}
 
 	level := parseLogLevel(*logLevel)
@@ -51,7 +56,15 @@ func main() {
 		authenticator = auth.NewJWTAuthenticator(keyStore)
 	}
 
-	server := relay.NewServer(*addr, authenticator)
+	var notifs *notifications.Client
+	if *relayWebhookSecret != "" && *authBackendURL != "" {
+		notifs = notifications.NewClient(*authBackendURL, *relayWebhookSecret)
+		slog.Info("push notifications enabled")
+	} else {
+		slog.Info("push notifications disabled (no webhook secret)")
+	}
+
+	server := relay.NewServer(*addr, authenticator, notifs)
 
 	if err := server.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.Error("server error", "err", err)

--- a/internal/notifications/client.go
+++ b/internal/notifications/client.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+const (
+	BridgeStatusConnected    = "connected"
+	BridgeStatusDisconnected = "disconnected"
+)
+
 type BridgeStatusPayload struct {
 	UserID    string `json:"userId"`
 	Status    string `json:"status"`

--- a/internal/notifications/client.go
+++ b/internal/notifications/client.go
@@ -1,0 +1,64 @@
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type BridgeStatusPayload struct {
+	UserID    string `json:"userId"`
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp"`
+}
+
+type Client struct {
+	baseURL    string
+	secret     string
+	httpClient *http.Client
+}
+
+func NewClient(baseURL string, secret string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		secret:  secret,
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+func (c *Client) NotifyBridgeStatus(ctx context.Context, userID string, status string) error {
+	payload := BridgeStatusPayload{
+		UserID:    userID,
+		Status:    status,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/internal/bridge-status", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Relay-Secret", c.secret)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/notifications/client_test.go
+++ b/internal/notifications/client_test.go
@@ -35,8 +35,8 @@ func TestClient_NotifyBridgeStatus_Success(t *testing.T) {
 		if payload.UserID != "user-123" {
 			t.Fatalf("expected userId user-123, got %q", payload.UserID)
 		}
-		if payload.Status != "connected" {
-			t.Fatalf("expected status connected, got %q", payload.Status)
+		if payload.Status != BridgeStatusConnected {
+			t.Fatalf("expected status %s, got %q", BridgeStatusConnected, payload.Status)
 		}
 		if _, err := time.Parse(time.RFC3339, payload.Timestamp); err != nil {
 			t.Fatalf("timestamp not RFC3339: %v", err)
@@ -47,7 +47,7 @@ func TestClient_NotifyBridgeStatus_Success(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(ts.URL, secret)
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", "connected")
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", BridgeStatusConnected)
 	if err != nil {
 		t.Fatalf("NotifyBridgeStatus returned error: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestClient_NotifyBridgeStatus_Unauthorized(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(ts.URL, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", "connected")
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", BridgeStatusConnected)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -76,7 +76,7 @@ func TestClient_NotifyBridgeStatus_ServerError(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(ts.URL, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", "disconnected")
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", BridgeStatusDisconnected)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -93,7 +93,7 @@ func TestClient_NotifyBridgeStatus_ServerUnreachable(t *testing.T) {
 	ts.Close()
 
 	client := NewClient(url, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", "connected")
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", BridgeStatusConnected)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/notifications/client_test.go
+++ b/internal/notifications/client_test.go
@@ -1,0 +1,100 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClient_NotifyBridgeStatus_Success(t *testing.T) {
+	const secret = "test-secret"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/internal/bridge-status" {
+			t.Fatalf("expected /internal/bridge-status, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Relay-Secret"); got != secret {
+			t.Fatalf("expected X-Relay-Secret %q, got %q", secret, got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("expected Content-Type application/json, got %q", got)
+		}
+
+		var payload BridgeStatusPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+
+		if payload.UserID != "user-123" {
+			t.Fatalf("expected userId user-123, got %q", payload.UserID)
+		}
+		if payload.Status != "connected" {
+			t.Fatalf("expected status connected, got %q", payload.Status)
+		}
+		if _, err := time.Parse(time.RFC3339, payload.Timestamp); err != nil {
+			t.Fatalf("timestamp not RFC3339: %v", err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, secret)
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", "connected")
+	if err != nil {
+		t.Fatalf("NotifyBridgeStatus returned error: %v", err)
+	}
+}
+
+func TestClient_NotifyBridgeStatus_Unauthorized(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, "secret")
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", "connected")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected status: 401") {
+		t.Fatalf("expected unexpected status: 401 error, got %v", err)
+	}
+}
+
+func TestClient_NotifyBridgeStatus_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, "secret")
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", "disconnected")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected status") {
+		t.Fatalf("expected unexpected status error, got %v", err)
+	}
+}
+
+func TestClient_NotifyBridgeStatus_ServerUnreachable(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	url := ts.URL
+	ts.Close()
+
+	client := NewClient(url, "secret")
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", "connected")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/sesori-ai/sesori_relay_server/internal/auth"
+	"github.com/sesori-ai/sesori_relay_server/internal/notifications"
 	"github.com/sesori-ai/sesori_relay_server/internal/protocol"
 )
 
@@ -66,7 +67,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	slog.Debug("connection joined group", "userID", userID, "role", authMsg.Role)
 	if authMsg.Role == protocol.RoleBridge {
-		handleBridge(r.Context(), conn, group, s.manager, userID)
+		handleBridge(r.Context(), conn, group, s.manager, userID, s.notifications)
 		return
 	}
 	handlePhone(r.Context(), conn, group, s.manager, userID)
@@ -123,7 +124,7 @@ func startPingLoop(ctx context.Context, cancel context.CancelFunc, conn *websock
 	}()
 }
 
-func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID string) {
+func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID string, notificationsClient *notifications.Client) {
 	group.mu.Lock()
 	oldBridge := group.Bridge
 	connCtx, connCancel := context.WithCancel(ctx)
@@ -143,6 +144,14 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		_ = phone.Conn.Write(ctx, websocket.MessageText, bridgeConnectedJSON)
 	}
 
+	if notificationsClient != nil {
+		go func() {
+			if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, "connected"); err != nil {
+				slog.Warn("failed to notify bridge connected", "error", err, "userId", userID)
+			}
+		}()
+	}
+
 	defer func() {
 		connCancel()
 		group.mu.Lock()
@@ -155,6 +164,15 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		for _, phone := range phones {
 			_ = phone.Conn.Write(ctx, websocket.MessageText, bridgeDisconnectedJSON)
 		}
+
+		if notificationsClient != nil {
+			go func() {
+				if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, "disconnected"); err != nil {
+					slog.Warn("failed to notify bridge disconnected", "error", err, "userId", userID)
+				}
+			}()
+		}
+
 		manager.RemoveGroupIfEmpty(userID)
 	}()
 

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -146,7 +146,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 
 	if notificationsClient != nil {
 		go func() {
-			if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, "connected"); err != nil {
+			if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, notifications.BridgeStatusConnected); err != nil {
 				slog.Warn("failed to notify bridge connected", "error", err, "userId", userID)
 			}
 		}()
@@ -167,7 +167,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 
 		if notificationsClient != nil {
 			go func() {
-				if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, "disconnected"); err != nil {
+				if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, notifications.BridgeStatusDisconnected); err != nil {
 					slog.Warn("failed to notify bridge disconnected", "error", err, "userId", userID)
 				}
 			}()

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -52,7 +52,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	}
 
 	jwtAuth := auth.NewJWTAuthenticator(ks)
-	relayServer := NewServer(":0", jwtAuth)
+	relayServer := NewServer(":0", jwtAuth, nil)
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		relayServer.handleWebSocket(w, r)

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -7,25 +7,28 @@ import (
 	"time"
 
 	"github.com/sesori-ai/sesori_relay_server/internal/auth"
+	"github.com/sesori-ai/sesori_relay_server/internal/notifications"
 )
 
 // Server is the relay WebSocket server. It manages rooms, rate limiting, and
 // delegates authentication to the provided Authenticator (nil = auth disabled).
 type Server struct {
-	addr        string
-	manager     *GroupManager
-	rateLimiter *RateLimiter
-	httpServer  *http.Server
-	jwtAuth     *auth.JWTAuthenticator
+	addr          string
+	manager       *GroupManager
+	rateLimiter   *RateLimiter
+	httpServer    *http.Server
+	jwtAuth       *auth.JWTAuthenticator
+	notifications *notifications.Client
 }
 
 // NewServer creates a relay server. Pass a nil authenticator to disable auth.
-func NewServer(addr string, jwtAuth *auth.JWTAuthenticator) *Server {
+func NewServer(addr string, jwtAuth *auth.JWTAuthenticator, notifs *notifications.Client) *Server {
 	return &Server{
-		addr:        addr,
-		manager:     NewGroupManager(),
-		rateLimiter: NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
-		jwtAuth:     jwtAuth,
+		addr:          addr,
+		manager:       NewGroupManager(),
+		rateLimiter:   NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
+		jwtAuth:       jwtAuth,
+		notifications: notifs,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add NotificationClient HTTP client for auth server bridge-status webhook
- Integrate fire-and-forget bridge status notifications into handleBridge lifecycle
- Add RELAY_WEBHOOK_SECRET configuration (flag + env var)

## How It Works
When a bridge connects or disconnects, a goroutine POSTs to the auth server's `/internal/bridge-status` endpoint. The auth server sends FCM push to the user's devices. Fire-and-forget — never blocks relay.

## Configuration
- `RELAY_WEBHOOK_SECRET` env var or `--relay-webhook-secret` flag
- If empty, notifications disabled

## Tests
- NotificationClient unit tests (4), handler integration tests updated

## Related PRs
- Auth Server: https://github.com/sesori-ai/sesori_auth_server/pull/15
- Monorepo: https://github.com/sesori-ai/sesori_apps_monorepo/pull/11