### PR TITLE
feat: forward bridgeId from bridge to auth server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 vendor/
 *.gitkeep
 .env
+.sisyphus/

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ The server listens on `:8080` by default.
 |------|---------|---------|-------------|
 | `--addr` | `RELAY_ADDR` | `:8080` | Listen address |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
-
-See [`.env.example`](.env.example) for a template.
+| `--require-bridge-id` | `RELAY_REQUIRE_BRIDGE_ID` | `false` | Require `bridgeId` field on bridge auth messages. Default `false` accepts legacy bridges (no `bridgeId`) and logs a warning. Set `true` to enforce after the bridge fleet has rolled over. |
 
 ## Endpoints
 
@@ -86,8 +85,14 @@ The GitHub Actions workflows run on every push and PR:
 Every client sends this as the first WebSocket message (plaintext JSON):
 
 ```json
-{ "type": "auth", "token": "<JWT>", "role": "bridge" }
+{ "type": "auth", "token": "<JWT>", "role": "bridge", "bridgeId": "br_..." }
 ```
+
+The `bridgeId` field is optional for `role: "phone"` (ignored) and is
+optional for `role: "bridge"` unless the relay was started with
+`--require-bridge-id=true` (or `RELAY_REQUIRE_BRIDGE_ID=true`). Format:
+`^br_[A-Za-z0-9_-]{8,32}$`. The relay does not validate the value
+against any database; it only forwards it to the auth server.
 
 Roles: `"bridge"` or `"phone"`. The relay closes the connection if auth fails.
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,22 @@ The GitHub Actions workflows run on every push and PR:
 Every client sends this as the first WebSocket message (plaintext JSON):
 
 ```json
-{ "type": "auth", "token": "<JWT>", "role": "bridge", "bridgeId": "br_..." }
+{ "type": "auth", "token": "<user access JWT>", "role": "bridge", "bridgeId": "br_..." }
 ```
+
+Both roles authenticate with the user's **access token** (`tokenType:
+"access"`, `aud: "mobile"`); no other token type is accepted.
 
 The `bridgeId` field is optional for `role: "phone"` (ignored) and is
 optional for `role: "bridge"` unless the relay was started with
 `--require-bridge-id=true` (or `RELAY_REQUIRE_BRIDGE_ID=true`). Format:
 `^br_[A-Za-z0-9_-]{8,32}$`. The relay does not validate the value
-against any database; it only forwards it to the auth server.
+against any database at handshake time; it forwards it to the auth
+server in the bridge-status report. If the auth server answers that
+report with an explicit HTTP 404 (bridgeId unknown, revoked, or owned
+by another user), the relay closes that bridge connection with close
+code `4006` (bridge revoked). Transport errors, timeouts, and 5xx
+responses are fail-open: the connection stays up.
 
 Roles: `"bridge"` or `"phone"`. The relay closes the connection if auth fails.
 

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -31,8 +33,15 @@ func main() {
 	if *relayWebhookSecret == "" {
 		*relayWebhookSecret = os.Getenv("RELAY_WEBHOOK_SECRET")
 	}
-	if v := os.Getenv("RELAY_REQUIRE_BRIDGE_ID"); v != "" {
-		*requireBridgeID = v == "true" || v == "1"
+	if !flagWasSet("require-bridge-id") {
+		v, ok, err := envBool("RELAY_REQUIRE_BRIDGE_ID")
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "invalid RELAY_REQUIRE_BRIDGE_ID: %v\n", err)
+			os.Exit(1)
+		}
+		if ok {
+			*requireBridgeID = v
+		}
 	}
 
 	level := parseLogLevel(*logLevel)
@@ -76,6 +85,29 @@ func main() {
 	}
 
 	slog.Info("relay server stopped")
+}
+
+func flagWasSet(name string) bool {
+	seen := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			seen = true
+		}
+	})
+	return seen
+}
+
+func envBool(name string) (bool, bool, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return false, false, nil
+	}
+
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, true, err
+	}
+	return value, true, nil
 }
 
 func parseLogLevel(s string) slog.Level {

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -21,6 +21,7 @@ func main() {
 	logLevel := flag.String("log-level", "info", "log level (debug, info, warn, error)")
 	authBackendURL := flag.String("auth-backend-url", "", "auth backend base URL (e.g. https://auth.example.com); auth is disabled when empty")
 	relayWebhookSecret := flag.String("relay-webhook-secret", "", "shared secret for auth server webhook")
+	requireBridgeID := flag.Bool("require-bridge-id", false, "require bridgeId field on bridge auth messages (transition gate; set true once the bridge fleet has rolled over)")
 	flag.Parse()
 
 	// Also honour the AUTH_BACKEND_URL environment variable (flag takes precedence).
@@ -29,6 +30,9 @@ func main() {
 	}
 	if *relayWebhookSecret == "" {
 		*relayWebhookSecret = os.Getenv("RELAY_WEBHOOK_SECRET")
+	}
+	if v := os.Getenv("RELAY_REQUIRE_BRIDGE_ID"); v != "" {
+		*requireBridgeID = v == "true" || v == "1"
 	}
 
 	level := parseLogLevel(*logLevel)
@@ -43,7 +47,7 @@ func main() {
 		slog.Info("auth disabled (no --auth-backend-url provided)")
 	}
 
-	slog.Info("starting relay server", "addr", *addr, "log-level", *logLevel)
+	slog.Info("starting relay server", "addr", *addr, "log-level", *logLevel, "require-bridge-id", *requireBridgeID)
 
 	var authenticator *auth.JWTAuthenticator
 	if *authBackendURL != "" {
@@ -64,7 +68,7 @@ func main() {
 		slog.Info("push notifications disabled (no webhook secret)")
 	}
 
-	server := relay.NewServer(*addr, authenticator, notifs)
+	server := relay.NewServer(*addr, authenticator, notifs, *requireBridgeID)
 
 	if err := server.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.Error("server error", "err", err)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,19 +9,8 @@ import (
 
 // AuthResult holds the authenticated identity and token metadata.
 type AuthResult struct {
-	UserID    string
-	Expiry    time.Time
-	TokenType string
-	Audience  string
-	BridgeID  string
-}
-
-func (r AuthResult) IsAccessToken() bool {
-	return r.TokenType == tokenTypeAccess && r.Audience == audienceMobile
-}
-
-func (r AuthResult) IsBridgeTokenFor(bridgeID string) bool {
-	return r.TokenType == tokenTypeBridge && r.Audience == audienceBridge && r.BridgeID == bridgeID
+	UserID string
+	Expiry time.Time
 }
 
 // Authenticator authenticates a WebSocket connection. Implementations read

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,11 +17,11 @@ type AuthResult struct {
 }
 
 func (r AuthResult) IsAccessToken() bool {
-	return r.TokenType == "access" && r.Audience == "mobile"
+	return r.TokenType == tokenTypeAccess && r.Audience == audienceMobile
 }
 
 func (r AuthResult) IsBridgeTokenFor(bridgeID string) bool {
-	return r.TokenType == "bridge" && r.Audience == "bridge" && r.BridgeID == bridgeID
+	return r.TokenType == tokenTypeBridge && r.Audience == audienceBridge && r.BridgeID == bridgeID
 }
 
 // Authenticator authenticates a WebSocket connection. Implementations read

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,8 +9,19 @@ import (
 
 // AuthResult holds the authenticated identity and token metadata.
 type AuthResult struct {
-	UserID string
-	Expiry time.Time
+	UserID    string
+	Expiry    time.Time
+	TokenType string
+	Audience  string
+	BridgeID  string
+}
+
+func (r AuthResult) IsAccessToken() bool {
+	return r.TokenType == "access" && r.Audience == "mobile"
+}
+
+func (r AuthResult) IsBridgeTokenFor(bridgeID string) bool {
+	return r.TokenType == "bridge" && r.Audience == "bridge" && r.BridgeID == bridgeID
 }
 
 // Authenticator authenticates a WebSocket connection. Implementations read

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -13,9 +13,7 @@ import (
 
 const (
 	tokenTypeAccess = "access"
-	tokenTypeBridge = "bridge"
 	audienceMobile  = "mobile"
-	audienceBridge  = "bridge"
 	issuerBackend   = "auth-backend"
 )
 
@@ -68,7 +66,7 @@ func (a *JWTAuthenticator) Authenticate(ctx context.Context, conn *websocket.Con
 		return AuthResult{}, err
 	}
 
-	slog.Debug("connection authenticated", "userId", result.UserID, "tokenType", result.TokenType)
+	slog.Debug("connection authenticated", "userId", result.UserID)
 	return result, nil
 }
 
@@ -109,8 +107,9 @@ func (a *JWTAuthenticator) verifyToken(raw string) (*jwt.Token, error) {
 	return token, err
 }
 
-// validateClaims extracts and validates the required JWT claims. Accepted token
-// types are "access" and "bridge"; "refresh" tokens are rejected.
+// validateClaims extracts and validates the required JWT claims. Only user
+// access tokens (tokenType "access", aud "mobile") are accepted; every other
+// token type (refresh, legacy bridge-typed tokens) is rejected.
 func validateClaims(token *jwt.Token) (AuthResult, error) {
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
@@ -129,7 +128,7 @@ func validateClaims(token *jwt.Token) (AuthResult, error) {
 	if err != nil {
 		return AuthResult{}, err
 	}
-	if tokenType != tokenTypeAccess && tokenType != tokenTypeBridge {
+	if tokenType != tokenTypeAccess {
 		return AuthResult{}, fmt.Errorf("invalid tokenType claim: %s", tokenType)
 	}
 
@@ -137,11 +136,8 @@ func validateClaims(token *jwt.Token) (AuthResult, error) {
 	if err != nil {
 		return AuthResult{}, err
 	}
-	if aud != audienceMobile && aud != audienceBridge {
+	if aud != audienceMobile {
 		return AuthResult{}, fmt.Errorf("invalid aud claim: %s", aud)
-	}
-	if (tokenType == tokenTypeAccess && aud != audienceMobile) || (tokenType == tokenTypeBridge && aud != audienceBridge) {
-		return AuthResult{}, fmt.Errorf("invalid tokenType/aud pair: %s/%s", tokenType, aud)
 	}
 
 	iss, err := requiredStringClaim(claims, "iss")
@@ -157,23 +153,9 @@ func validateClaims(token *jwt.Token) (AuthResult, error) {
 		return AuthResult{}, err
 	}
 
-	bridgeID := ""
-	if tokenType == tokenTypeBridge {
-		bridgeID, err = requiredStringClaim(claims, "bridgeId")
-		if err != nil {
-			return AuthResult{}, err
-		}
-		if bridgeID == "" {
-			return AuthResult{}, fmt.Errorf("bridgeId claim is empty")
-		}
-	}
-
 	return AuthResult{
-		UserID:    userId,
-		Expiry:    time.Unix(int64(expFloat), 0),
-		TokenType: tokenType,
-		Audience:  aud,
-		BridgeID:  bridgeID,
+		UserID: userId,
+		Expiry: time.Unix(int64(expFloat), 0),
 	}, nil
 }
 

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -62,13 +62,13 @@ func (a *JWTAuthenticator) Authenticate(ctx context.Context, conn *websocket.Con
 		return AuthResult{}, fmt.Errorf("JWT verification failed: %w", err)
 	}
 
-	result, tokenType, err := validateClaims(token)
+	result, err := validateClaims(token)
 	if err != nil {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), err.Error())
 		return AuthResult{}, err
 	}
 
-	slog.Debug("connection authenticated", "userId", result.UserID, "tokenType", tokenType)
+	slog.Debug("connection authenticated", "userId", result.UserID, "tokenType", result.TokenType)
 	return result, nil
 }
 
@@ -78,7 +78,7 @@ func (a *JWTAuthenticator) Validate(raw string) (AuthResult, error) {
 		return AuthResult{}, fmt.Errorf("JWT verification failed: %w", err)
 	}
 
-	result, _, err := validateClaims(token)
+	result, err := validateClaims(token)
 	if err != nil {
 		return AuthResult{}, err
 	}
@@ -109,56 +109,72 @@ func (a *JWTAuthenticator) verifyToken(raw string) (*jwt.Token, error) {
 	return token, err
 }
 
-// validateClaims extracts and validates the required JWT claims. Returns the
-// auth result and token type (for logging). Accepted token types are "access"
-// and "bridge"; "refresh" tokens are rejected.
-func validateClaims(token *jwt.Token) (AuthResult, string, error) {
+// validateClaims extracts and validates the required JWT claims. Accepted token
+// types are "access" and "bridge"; "refresh" tokens are rejected.
+func validateClaims(token *jwt.Token) (AuthResult, error) {
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return AuthResult{}, "", fmt.Errorf("invalid JWT claims type")
+		return AuthResult{}, fmt.Errorf("invalid JWT claims type")
 	}
 
 	userId, err := requiredStringClaim(claims, "userId")
 	if err != nil {
-		return AuthResult{}, "", err
+		return AuthResult{}, err
 	}
 	if userId == "" {
-		return AuthResult{}, "", fmt.Errorf("userId claim is empty")
+		return AuthResult{}, fmt.Errorf("userId claim is empty")
 	}
 
 	tokenType, err := requiredStringClaim(claims, "tokenType")
 	if err != nil {
-		return AuthResult{}, "", err
+		return AuthResult{}, err
 	}
 	if tokenType != tokenTypeAccess && tokenType != tokenTypeBridge {
-		return AuthResult{}, "", fmt.Errorf("invalid tokenType claim: %s", tokenType)
+		return AuthResult{}, fmt.Errorf("invalid tokenType claim: %s", tokenType)
 	}
 
 	aud, err := audienceClaim(claims)
 	if err != nil {
-		return AuthResult{}, "", err
+		return AuthResult{}, err
 	}
 	if aud != audienceMobile && aud != audienceBridge {
-		return AuthResult{}, "", fmt.Errorf("invalid aud claim: %s", aud)
+		return AuthResult{}, fmt.Errorf("invalid aud claim: %s", aud)
+	}
+	if (tokenType == tokenTypeAccess && aud != audienceMobile) || (tokenType == tokenTypeBridge && aud != audienceBridge) {
+		return AuthResult{}, fmt.Errorf("invalid tokenType/aud pair: %s/%s", tokenType, aud)
 	}
 
 	iss, err := requiredStringClaim(claims, "iss")
 	if err != nil {
-		return AuthResult{}, "", err
+		return AuthResult{}, err
 	}
 	if iss != issuerBackend {
-		return AuthResult{}, "", fmt.Errorf("invalid iss claim: %s", iss)
+		return AuthResult{}, fmt.Errorf("invalid iss claim: %s", iss)
 	}
 
 	expFloat, err := requiredFloatClaim(claims, "exp")
 	if err != nil {
-		return AuthResult{}, "", err
+		return AuthResult{}, err
+	}
+
+	bridgeID := ""
+	if tokenType == tokenTypeBridge {
+		bridgeID, err = requiredStringClaim(claims, "bridgeId")
+		if err != nil {
+			return AuthResult{}, err
+		}
+		if bridgeID == "" {
+			return AuthResult{}, fmt.Errorf("bridgeId claim is empty")
+		}
 	}
 
 	return AuthResult{
-		UserID: userId,
-		Expiry: time.Unix(int64(expFloat), 0),
-	}, tokenType, nil
+		UserID:    userId,
+		Expiry:    time.Unix(int64(expFloat), 0),
+		TokenType: tokenType,
+		Audience:  aud,
+		BridgeID:  bridgeID,
+	}, nil
 }
 
 // requiredStringClaim extracts a required string claim from the map.

--- a/internal/notifications/client.go
+++ b/internal/notifications/client.go
@@ -21,6 +21,12 @@ type BridgeStatusPayload struct {
 	Timestamp string `json:"timestamp"`
 }
 
+type BridgeTokenValidationPayload struct {
+	UserID      string `json:"userId"`
+	BridgeID    string `json:"bridgeId"`
+	BridgeToken string `json:"bridgeToken"`
+}
+
 type Client struct {
 	baseURL    string
 	secret     string
@@ -51,6 +57,38 @@ func (c *Client) NotifyBridgeStatus(ctx context.Context, userID, bridgeID, statu
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/internal/bridge-status", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Relay-Secret", c.secret)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (c *Client) ValidateBridgeToken(ctx context.Context, userID, bridgeID, bridgeToken string) error {
+	payload := BridgeTokenValidationPayload{
+		UserID:      userID,
+		BridgeID:    bridgeID,
+		BridgeToken: bridgeToken,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/internal/bridge-token/validate", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}

--- a/internal/notifications/client.go
+++ b/internal/notifications/client.go
@@ -16,6 +16,7 @@ const (
 
 type BridgeStatusPayload struct {
 	UserID    string `json:"userId"`
+	BridgeID  string `json:"bridgeId,omitempty"`
 	Status    string `json:"status"`
 	Timestamp string `json:"timestamp"`
 }
@@ -36,9 +37,10 @@ func NewClient(baseURL string, secret string) *Client {
 	}
 }
 
-func (c *Client) NotifyBridgeStatus(ctx context.Context, userID string, status string) error {
+func (c *Client) NotifyBridgeStatus(ctx context.Context, userID, bridgeID, status string) error {
 	payload := BridgeStatusPayload{
 		UserID:    userID,
+		BridgeID:  bridgeID,
 		Status:    status,
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	}

--- a/internal/notifications/client.go
+++ b/internal/notifications/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -14,17 +15,17 @@ const (
 	BridgeStatusDisconnected = "disconnected"
 )
 
+// ErrBridgeNotFound is returned when the auth server responds with an explicit
+// HTTP 404 to a bridge-status report, meaning the reported bridgeId is unknown,
+// revoked, or not owned by the user. Transport errors and other status codes
+// return generic errors so callers can stay fail-open on them.
+var ErrBridgeNotFound = errors.New("bridge not found")
+
 type BridgeStatusPayload struct {
 	UserID    string `json:"userId"`
 	BridgeID  string `json:"bridgeId,omitempty"`
 	Status    string `json:"status"`
 	Timestamp string `json:"timestamp"`
-}
-
-type BridgeTokenValidationPayload struct {
-	UserID      string `json:"userId"`
-	BridgeID    string `json:"bridgeId"`
-	BridgeToken string `json:"bridgeToken"`
 }
 
 type Client struct {
@@ -69,38 +70,9 @@ func (c *Client) NotifyBridgeStatus(ctx context.Context, userID, bridgeID, statu
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrBridgeNotFound
 	}
-
-	return nil
-}
-
-func (c *Client) ValidateBridgeToken(ctx context.Context, userID, bridgeID, bridgeToken string) error {
-	payload := BridgeTokenValidationPayload{
-		UserID:      userID,
-		BridgeID:    bridgeID,
-		BridgeToken: bridgeToken,
-	}
-
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("marshal payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/internal/bridge-token/validate", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Relay-Secret", c.secret)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("send request: %w", err)
-	}
-	defer resp.Body.Close()
-
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
 	}

--- a/internal/notifications/client_test.go
+++ b/internal/notifications/client_test.go
@@ -35,6 +35,9 @@ func TestClient_NotifyBridgeStatus_Success(t *testing.T) {
 		if payload.UserID != "user-123" {
 			t.Fatalf("expected userId user-123, got %q", payload.UserID)
 		}
+		if payload.BridgeID != "br_abc12345" {
+			t.Fatalf("expected bridgeId br_abc12345, got %q", payload.BridgeID)
+		}
 		if payload.Status != BridgeStatusConnected {
 			t.Fatalf("expected status %s, got %q", BridgeStatusConnected, payload.Status)
 		}
@@ -47,8 +50,42 @@ func TestClient_NotifyBridgeStatus_Success(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(ts.URL, secret)
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", BridgeStatusConnected)
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusConnected)
 	if err != nil {
+		t.Fatalf("NotifyBridgeStatus returned error: %v", err)
+	}
+}
+
+func TestClient_NotifyBridgeStatus_LegacyNoBridgeID(t *testing.T) {
+	const secret = "test-secret"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload BridgeStatusPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.UserID != "user-123" {
+			t.Fatalf("expected userId user-123, got %q", payload.UserID)
+		}
+		if payload.BridgeID != "" {
+			t.Fatalf("expected empty bridgeId in legacy path, got %q", payload.BridgeID)
+		}
+
+		// Re-marshal and confirm the field is absent (omitempty should drop it from JSON).
+		body, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("re-marshal: %v", err)
+		}
+		if strings.Contains(string(body), "bridgeId") {
+			t.Fatalf("expected payload to omit bridgeId key, got %s", string(body))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, secret)
+	if err := client.NotifyBridgeStatus(context.Background(), "user-123", "", BridgeStatusConnected); err != nil {
 		t.Fatalf("NotifyBridgeStatus returned error: %v", err)
 	}
 }
@@ -60,7 +97,7 @@ func TestClient_NotifyBridgeStatus_Unauthorized(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(ts.URL, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", BridgeStatusConnected)
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusConnected)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -76,7 +113,7 @@ func TestClient_NotifyBridgeStatus_ServerError(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(ts.URL, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", BridgeStatusDisconnected)
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusDisconnected)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -93,7 +130,7 @@ func TestClient_NotifyBridgeStatus_ServerUnreachable(t *testing.T) {
 	ts.Close()
 
 	client := NewClient(url, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", BridgeStatusConnected)
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusConnected)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/notifications/client_test.go
+++ b/internal/notifications/client_test.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -60,8 +61,16 @@ func TestClient_NotifyBridgeStatus_LegacyNoBridgeID(t *testing.T) {
 	const secret = "test-secret"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read payload: %v", err)
+		}
+		if strings.Contains(string(body), "bridgeId") {
+			t.Fatalf("expected payload to omit bridgeId key, got %s", string(body))
+		}
+
 		var payload BridgeStatusPayload
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		if err := json.Unmarshal(body, &payload); err != nil {
 			t.Fatalf("decode payload: %v", err)
 		}
 		if payload.UserID != "user-123" {
@@ -69,15 +78,6 @@ func TestClient_NotifyBridgeStatus_LegacyNoBridgeID(t *testing.T) {
 		}
 		if payload.BridgeID != "" {
 			t.Fatalf("expected empty bridgeId in legacy path, got %q", payload.BridgeID)
-		}
-
-		// Re-marshal and confirm the field is absent (omitempty should drop it from JSON).
-		body, err := json.Marshal(payload)
-		if err != nil {
-			t.Fatalf("re-marshal: %v", err)
-		}
-		if strings.Contains(string(body), "bridgeId") {
-			t.Fatalf("expected payload to omit bridgeId key, got %s", string(body))
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/internal/notifications/client_test.go
+++ b/internal/notifications/client_test.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -120,6 +121,25 @@ func TestClient_NotifyBridgeStatus_ServerError(t *testing.T) {
 	if !strings.Contains(err.Error(), "unexpected status") {
 		t.Fatalf("expected unexpected status error, got %v", err)
 	}
+	if errors.Is(err, ErrBridgeNotFound) {
+		t.Fatalf("5xx must not map to ErrBridgeNotFound, got %v", err)
+	}
+}
+
+func TestClient_NotifyBridgeStatus_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, "secret")
+	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusConnected)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrBridgeNotFound) {
+		t.Fatalf("expected ErrBridgeNotFound, got %v", err)
+	}
 }
 
 func TestClient_NotifyBridgeStatus_ServerUnreachable(t *testing.T) {
@@ -134,58 +154,7 @@ func TestClient_NotifyBridgeStatus_ServerUnreachable(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-}
-
-func TestClient_ValidateBridgeToken_Success(t *testing.T) {
-	const secret = "test-secret"
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Fatalf("expected POST, got %s", r.Method)
-		}
-		if r.URL.Path != "/internal/bridge-token/validate" {
-			t.Fatalf("expected /internal/bridge-token/validate, got %s", r.URL.Path)
-		}
-		if got := r.Header.Get("X-Relay-Secret"); got != secret {
-			t.Fatalf("expected X-Relay-Secret %q, got %q", secret, got)
-		}
-
-		var payload BridgeTokenValidationPayload
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode payload: %v", err)
-		}
-		if payload.UserID != "user-123" {
-			t.Fatalf("expected userId user-123, got %q", payload.UserID)
-		}
-		if payload.BridgeID != "br_abc12345" {
-			t.Fatalf("expected bridgeId br_abc12345, got %q", payload.BridgeID)
-		}
-		if payload.BridgeToken != "bridge-token" {
-			t.Fatalf("expected bridge token, got %q", payload.BridgeToken)
-		}
-
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	client := NewClient(ts.URL, secret)
-	if err := client.ValidateBridgeToken(context.Background(), "user-123", "br_abc12345", "bridge-token"); err != nil {
-		t.Fatalf("ValidateBridgeToken returned error: %v", err)
-	}
-}
-
-func TestClient_ValidateBridgeToken_Rejected(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer ts.Close()
-
-	client := NewClient(ts.URL, "secret")
-	err := client.ValidateBridgeToken(context.Background(), "user-123", "br_abc12345", "bridge-token")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "unexpected status: 404") {
-		t.Fatalf("expected unexpected status: 404 error, got %v", err)
+	if errors.Is(err, ErrBridgeNotFound) {
+		t.Fatalf("transport errors must not map to ErrBridgeNotFound, got %v", err)
 	}
 }

--- a/internal/notifications/client_test.go
+++ b/internal/notifications/client_test.go
@@ -135,3 +135,57 @@ func TestClient_NotifyBridgeStatus_ServerUnreachable(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 }
+
+func TestClient_ValidateBridgeToken_Success(t *testing.T) {
+	const secret = "test-secret"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/internal/bridge-token/validate" {
+			t.Fatalf("expected /internal/bridge-token/validate, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Relay-Secret"); got != secret {
+			t.Fatalf("expected X-Relay-Secret %q, got %q", secret, got)
+		}
+
+		var payload BridgeTokenValidationPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.UserID != "user-123" {
+			t.Fatalf("expected userId user-123, got %q", payload.UserID)
+		}
+		if payload.BridgeID != "br_abc12345" {
+			t.Fatalf("expected bridgeId br_abc12345, got %q", payload.BridgeID)
+		}
+		if payload.BridgeToken != "bridge-token" {
+			t.Fatalf("expected bridge token, got %q", payload.BridgeToken)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, secret)
+	if err := client.ValidateBridgeToken(context.Background(), "user-123", "br_abc12345", "bridge-token"); err != nil {
+		t.Fatalf("ValidateBridgeToken returned error: %v", err)
+	}
+}
+
+func TestClient_ValidateBridgeToken_Rejected(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, "secret")
+	err := client.ValidateBridgeToken(context.Background(), "user-123", "br_abc12345", "bridge-token")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected status: 404") {
+		t.Fatalf("expected unexpected status: 404 error, got %v", err)
+	}
+}

--- a/internal/protocol/closecodes.go
+++ b/internal/protocol/closecodes.go
@@ -1,9 +1,10 @@
 package protocol
 
 const (
-	CloseAuthFailure  = 4001
-	CloseAuthRequired = 4002
-	CloseRoomFull     = 4003
-	CloseRoomNotFound = 4004
-	CloseAccountFull  = 4005
+	CloseAuthFailure   = 4001
+	CloseAuthRequired  = 4002
+	CloseRoomFull      = 4003
+	CloseRoomNotFound  = 4004
+	CloseAccountFull   = 4005
+	CloseBridgeRevoked = 4006
 )

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -40,9 +40,10 @@ type KeyExchangeMessage struct {
 
 // RoleAuthMessage - client sends this plaintext as first message after WebSocket connect
 type RoleAuthMessage struct {
-	Type  string `json:"type"` // "auth"
-	Token string `json:"token"`
-	Role  string `json:"role"` // "bridge" or "phone"
+	Type     string `json:"type"` // "auth"
+	Token    string `json:"token"`
+	Role     string `json:"role"` // "bridge" or "phone"
+	BridgeID string `json:"bridgeId,omitempty"` // optional; bridge role only. Format: ^br_[A-Za-z0-9_-]{8,32}$. Required when the relay runs with --require-bridge-id.
 }
 
 // PhoneConnectedMessage is sent by relay to bridge when a phone joins.

--- a/internal/relay/account_group.go
+++ b/internal/relay/account_group.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Connection struct {
-	Conn   *websocket.Conn
-	ConnID uint16
-	Cancel context.CancelFunc
+	Conn     *websocket.Conn
+	ConnID   uint16
+	Cancel   context.CancelFunc
+	BridgeID string // empty for phones; populated for bridge connections (per-instance identifier from sesori_auth_server)
 }
 
 type AccountGroup struct {

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
@@ -83,36 +84,10 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridgeId required")
 			return
 		}
-		if authMsg.BridgeID != "" && !authResult.IsBridgeTokenFor(authMsg.BridgeID) {
-			s.manager.RemoveGroupIfEmpty(userID)
-			slog.Warn("bridge connection rejected: bridge token required", "userId", userID, "bridgeId", authMsg.BridgeID)
-			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridge token required")
-			return
-		}
-		if authMsg.BridgeID != "" && s.notifications != nil {
-			if err := s.notifications.ValidateBridgeToken(r.Context(), userID, authMsg.BridgeID, authMsg.Token); err != nil {
-				s.manager.RemoveGroupIfEmpty(userID)
-				slog.Warn("bridge connection rejected: bridge token revoked or unknown", "userId", userID, "bridgeId", authMsg.BridgeID, "err", err)
-				_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridge token revoked or unknown")
-				return
-			}
-		}
-		if !s.requireBridgeID && authMsg.BridgeID == "" {
-			if !authResult.IsAccessToken() {
-				s.manager.RemoveGroupIfEmpty(userID)
-				slog.Warn("legacy bridge connection rejected: access token required", "userId", userID)
-				_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "access token required")
-				return
-			}
+		if authMsg.BridgeID == "" {
 			slog.Warn("legacy bridge without bridgeId; set RELAY_REQUIRE_BRIDGE_ID=true to enforce", "userId", userID)
 		}
 		handleBridge(r.Context(), conn, group, s.manager, userID, authMsg.BridgeID, s.notifications)
-		return
-	}
-	if !authResult.IsAccessToken() {
-		s.manager.RemoveGroupIfEmpty(userID)
-		slog.Warn("phone connection rejected: access token required", "userId", userID)
-		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "access token required")
 		return
 	}
 	handlePhone(r.Context(), conn, group, s.manager, userID)
@@ -191,9 +166,23 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 
 	if notificationsClient != nil {
 		go func() {
-			if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusConnected); err != nil {
-				slog.Warn("failed to notify bridge connected", "error", err, "userId", userID, "bridgeId", bridgeID)
+			err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusConnected)
+			if err == nil {
+				return
 			}
+			if bridgeID != "" && errors.Is(err, notifications.ErrBridgeNotFound) {
+				// The auth server explicitly reported this bridgeId as unknown,
+				// revoked, or owned by another user. Close exactly this
+				// connection; unblocking its read loop runs the deferred
+				// cleanup below, which only touches the group if this
+				// connection is still the current bridge.
+				slog.Warn("bridge revoked; closing connection", "userId", userID, "bridgeId", bridgeID)
+				_ = conn.Close(websocket.StatusCode(protocol.CloseBridgeRevoked), "bridge revoked")
+				return
+			}
+			// Transport errors, timeouts, and 5xx are fail-open: log and keep
+			// the connection.
+			slog.Warn("failed to notify bridge connected", "error", err, "userId", userID, "bridgeId", bridgeID)
 		}()
 	}
 

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/coder/websocket"
@@ -20,6 +21,8 @@ const (
 	maxPhonesPerAccount = 5
 	pingInterval        = 30 * time.Second
 )
+
+var bridgeIDRegexp = regexp.MustCompile(`^br_[A-Za-z0-9_-]{8,32}$`)
 
 var (
 	bridgeConnectedJSON, _    = json.Marshal(protocol.BridgeConnectedMessage{Type: protocol.TypeBridgeConnected})
@@ -67,7 +70,20 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	slog.Debug("connection joined group", "userID", userID, "role", authMsg.Role)
 	if authMsg.Role == protocol.RoleBridge {
-		handleBridge(r.Context(), conn, group, s.manager, userID, s.notifications)
+		if authMsg.BridgeID != "" && !bridgeIDRegexp.MatchString(authMsg.BridgeID) {
+			s.manager.RemoveGroupIfEmpty(userID)
+			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid bridgeId format")
+			return
+		}
+		if s.requireBridgeID && authMsg.BridgeID == "" {
+			s.manager.RemoveGroupIfEmpty(userID)
+			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridgeId required")
+			return
+		}
+		if !s.requireBridgeID && authMsg.BridgeID == "" {
+			slog.Warn("legacy bridge without bridgeId; set RELAY_REQUIRE_BRIDGE_ID=true to enforce", "userId", userID)
+		}
+		handleBridge(r.Context(), conn, group, s.manager, userID, authMsg.BridgeID, s.notifications)
 		return
 	}
 	handlePhone(r.Context(), conn, group, s.manager, userID)
@@ -124,11 +140,11 @@ func startPingLoop(ctx context.Context, cancel context.CancelFunc, conn *websock
 	}()
 }
 
-func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID string, notificationsClient *notifications.Client) {
+func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID, bridgeID string, notificationsClient *notifications.Client) {
 	group.mu.Lock()
 	oldBridge := group.Bridge
 	connCtx, connCancel := context.WithCancel(ctx)
-	newConn := &Connection{Conn: conn, ConnID: 0, Cancel: connCancel}
+	newConn := &Connection{Conn: conn, ConnID: 0, Cancel: connCancel, BridgeID: bridgeID}
 	group.Bridge = newConn
 	group.mu.Unlock()
 	startPingLoop(connCtx, connCancel, conn)
@@ -146,7 +162,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 
 	if notificationsClient != nil {
 		go func() {
-			if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, notifications.BridgeStatusConnected); err != nil {
+			if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusConnected); err != nil {
 				slog.Warn("failed to notify bridge connected", "error", err, "userId", userID)
 			}
 		}()
@@ -167,7 +183,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 
 		if notificationsClient != nil {
 			go func() {
-				if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, notifications.BridgeStatusDisconnected); err != nil {
+				if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusDisconnected); err != nil {
 					slog.Warn("failed to notify bridge disconnected", "error", err, "userId", userID)
 				}
 			}()

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -89,7 +89,21 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridge token required")
 			return
 		}
+		if authMsg.BridgeID != "" && s.notifications != nil {
+			if err := s.notifications.ValidateBridgeToken(r.Context(), userID, authMsg.BridgeID, authMsg.Token); err != nil {
+				s.manager.RemoveGroupIfEmpty(userID)
+				slog.Warn("bridge connection rejected: bridge token revoked or unknown", "userId", userID, "bridgeId", authMsg.BridgeID, "err", err)
+				_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridge token revoked or unknown")
+				return
+			}
+		}
 		if !s.requireBridgeID && authMsg.BridgeID == "" {
+			if !authResult.IsAccessToken() {
+				s.manager.RemoveGroupIfEmpty(userID)
+				slog.Warn("legacy bridge connection rejected: access token required", "userId", userID)
+				_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "access token required")
+				return
+			}
 			slog.Warn("legacy bridge without bridgeId; set RELAY_REQUIRE_BRIDGE_ID=true to enforce", "userId", userID)
 		}
 		handleBridge(r.Context(), conn, group, s.manager, userID, authMsg.BridgeID, s.notifications)

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -61,10 +61,11 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authMsg, userID, ok := readAndValidateAuth(r.Context(), conn, s.jwtAuth)
+	authMsg, authResult, ok := readAndValidateAuth(r.Context(), conn, s.jwtAuth)
 	if !ok {
 		return
 	}
+	userID := authResult.UserID
 
 	group := s.manager.GetOrCreateGroup(userID)
 
@@ -82,43 +83,55 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridgeId required")
 			return
 		}
+		if authMsg.BridgeID != "" && !authResult.IsBridgeTokenFor(authMsg.BridgeID) {
+			s.manager.RemoveGroupIfEmpty(userID)
+			slog.Warn("bridge connection rejected: bridge token required", "userId", userID, "bridgeId", authMsg.BridgeID)
+			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridge token required")
+			return
+		}
 		if !s.requireBridgeID && authMsg.BridgeID == "" {
 			slog.Warn("legacy bridge without bridgeId; set RELAY_REQUIRE_BRIDGE_ID=true to enforce", "userId", userID)
 		}
 		handleBridge(r.Context(), conn, group, s.manager, userID, authMsg.BridgeID, s.notifications)
 		return
 	}
+	if !authResult.IsAccessToken() {
+		s.manager.RemoveGroupIfEmpty(userID)
+		slog.Warn("phone connection rejected: access token required", "userId", userID)
+		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "access token required")
+		return
+	}
 	handlePhone(r.Context(), conn, group, s.manager, userID)
 }
 
-func readAndValidateAuth(ctx context.Context, conn *websocket.Conn, jwtAuth *auth.JWTAuthenticator) (protocol.RoleAuthMessage, string, bool) {
+func readAndValidateAuth(ctx context.Context, conn *websocket.Conn, jwtAuth *auth.JWTAuthenticator) (protocol.RoleAuthMessage, auth.AuthResult, bool) {
 	authCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	msgType, data, err := conn.Read(authCtx)
 	if err != nil || msgType != websocket.MessageText {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthRequired), "auth required")
-		return protocol.RoleAuthMessage{}, "", false
+		return protocol.RoleAuthMessage{}, auth.AuthResult{}, false
 	}
 
 	var authMsg protocol.RoleAuthMessage
 	if err := json.Unmarshal(data, &authMsg); err != nil || authMsg.Type != protocol.TypeAuth {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "auth failed")
-		return protocol.RoleAuthMessage{}, "", false
+		return protocol.RoleAuthMessage{}, auth.AuthResult{}, false
 	}
 
 	if authMsg.Role != protocol.RoleBridge && authMsg.Role != protocol.RolePhone {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid role")
-		return protocol.RoleAuthMessage{}, "", false
+		return protocol.RoleAuthMessage{}, auth.AuthResult{}, false
 	}
 
 	result, err := jwtAuth.Validate(authMsg.Token)
 	if err != nil {
 		_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "auth failed")
-		return protocol.RoleAuthMessage{}, "", false
+		return protocol.RoleAuthMessage{}, auth.AuthResult{}, false
 	}
 
-	return authMsg, result.UserID, true
+	return authMsg, result, true
 }
 
 func startPingLoop(ctx context.Context, cancel context.CancelFunc, conn *websocket.Conn) {

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -174,24 +174,29 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		connCancel()
 		group.mu.Lock()
 		isCurrent := group.Bridge == newConn
+		currentBridgeID := ""
+		if group.Bridge != nil {
+			currentBridgeID = group.Bridge.BridgeID
+		}
 		if isCurrent {
 			group.Bridge = nil
 		}
 		group.mu.Unlock()
+		shouldNotifyDisconnected := isCurrent || (bridgeID != "" && bridgeID != currentBridgeID)
 
 		if isCurrent {
 			phones := group.AllPhones()
 			for _, phone := range phones {
 				_ = phone.Conn.Write(ctx, websocket.MessageText, bridgeDisconnectedJSON)
 			}
+		}
 
-			if notificationsClient != nil {
-				go func() {
-					if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusDisconnected); err != nil {
-						slog.Warn("failed to notify bridge disconnected", "error", err, "userId", userID, "bridgeId", bridgeID)
-					}
-				}()
-			}
+		if shouldNotifyDisconnected && notificationsClient != nil {
+			go func() {
+				if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusDisconnected); err != nil {
+					slog.Warn("failed to notify bridge disconnected", "error", err, "userId", userID, "bridgeId", bridgeID)
+				}
+			}()
 		}
 
 		manager.RemoveGroupIfEmpty(userID)

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -72,11 +72,13 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	if authMsg.Role == protocol.RoleBridge {
 		if authMsg.BridgeID != "" && !bridgeIDRegexp.MatchString(authMsg.BridgeID) {
 			s.manager.RemoveGroupIfEmpty(userID)
+			slog.Warn("bridge connection rejected: invalid bridgeId format", "userId", userID, "bridgeId", authMsg.BridgeID)
 			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid bridgeId format")
 			return
 		}
 		if s.requireBridgeID && authMsg.BridgeID == "" {
 			s.manager.RemoveGroupIfEmpty(userID)
+			slog.Warn("bridge connection rejected: bridgeId required", "userId", userID)
 			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridgeId required")
 			return
 		}
@@ -163,7 +165,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 	if notificationsClient != nil {
 		go func() {
 			if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusConnected); err != nil {
-				slog.Warn("failed to notify bridge connected", "error", err, "userId", userID)
+				slog.Warn("failed to notify bridge connected", "error", err, "userId", userID, "bridgeId", bridgeID)
 			}
 		}()
 	}
@@ -171,22 +173,25 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 	defer func() {
 		connCancel()
 		group.mu.Lock()
-		if group.Bridge == newConn {
+		isCurrent := group.Bridge == newConn
+		if isCurrent {
 			group.Bridge = nil
 		}
 		group.mu.Unlock()
 
-		phones := group.AllPhones()
-		for _, phone := range phones {
-			_ = phone.Conn.Write(ctx, websocket.MessageText, bridgeDisconnectedJSON)
-		}
+		if isCurrent {
+			phones := group.AllPhones()
+			for _, phone := range phones {
+				_ = phone.Conn.Write(ctx, websocket.MessageText, bridgeDisconnectedJSON)
+			}
 
-		if notificationsClient != nil {
-			go func() {
-				if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusDisconnected); err != nil {
-					slog.Warn("failed to notify bridge disconnected", "error", err, "userId", userID)
-				}
-			}()
+			if notificationsClient != nil {
+				go func() {
+					if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusDisconnected); err != nil {
+						slog.Warn("failed to notify bridge disconnected", "error", err, "userId", userID, "bridgeId", bridgeID)
+					}
+				}()
+			}
 		}
 
 		manager.RemoveGroupIfEmpty(userID)

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -101,6 +101,8 @@ func (e *testEnv) makeAccessToken(userID string) string {
 	return signed
 }
 
+// makeBridgeToken mints a legacy bridge-typed JWT. The auth server no longer
+// issues these; the relay must reject them for both roles.
 func (e *testEnv) makeBridgeToken(userID, bridgeID string) string {
 	claims := jwt.MapClaims{
 		"userId":    userID,
@@ -144,11 +146,7 @@ func (e *testEnv) connectBridgeWithID(t *testing.T, userID, bridgeID string) *we
 	if err != nil {
 		t.Fatalf("dial bridge: %v", err)
 	}
-	token := e.makeAccessToken(userID)
-	if bridgeID != "" {
-		token = e.makeBridgeToken(userID, bridgeID)
-	}
-	if err := sendAuth(ctx, conn, token, "bridge", bridgeID); err != nil {
+	if err := sendAuth(ctx, conn, e.makeAccessToken(userID), "bridge", bridgeID); err != nil {
 		conn.CloseNow()
 		t.Fatalf("sendAuth bridge: %v", err)
 	}
@@ -234,6 +232,22 @@ func expectNoMsg(t *testing.T, conn *websocket.Conn, timeout time.Duration) {
 	_, _, err := conn.Read(ctx)
 	if err == nil {
 		t.Error("expected no message but received one")
+	}
+}
+
+// expectOpen reads with a timeout and asserts the connection was NOT closed
+// by the server: a read timeout means the connection is still open, while a
+// close frame surfaces its status code.
+func expectOpen(t *testing.T, conn *websocket.Conn, timeout time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_, _, err := conn.Read(ctx)
+	if err == nil {
+		t.Fatal("expected no message on open connection, but received one")
+	}
+	if status := websocket.CloseStatus(err); status != -1 {
+		t.Fatalf("expected connection to stay open, got close status %d (err: %v)", status, err)
 	}
 }
 
@@ -625,7 +639,7 @@ func TestHandler_BridgeAuth_AcceptsBridgeID_PostTransition(t *testing.T) {
 	}
 }
 
-func TestHandler_BridgeAuth_RejectsAccessTokenWithBridgeID(t *testing.T) {
+func TestHandler_BridgeAuth_AcceptsAccessTokenWithBridgeID(t *testing.T) {
 	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
 	ctx := context.Background()
 
@@ -638,10 +652,14 @@ func TestHandler_BridgeAuth_RejectsAccessTokenWithBridgeID(t *testing.T) {
 	if err := sendAuth(ctx, conn, env.makeAccessToken("user1"), "bridge", "br_abc12345"); err != nil {
 		t.Fatalf("sendAuth bridge: %v", err)
 	}
-	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
+	time.Sleep(60 * time.Millisecond)
+
+	if env.relay.manager.Count() != 1 {
+		t.Errorf("expected 1 group (access token + bridgeId accepted), got %d", env.relay.manager.Count())
+	}
 }
 
-func TestHandler_BridgeAuth_RejectsBridgeTokenIDMismatch(t *testing.T) {
+func TestHandler_BridgeAuth_RejectsBridgeTypedToken(t *testing.T) {
 	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
 	ctx := context.Background()
 
@@ -651,7 +669,7 @@ func TestHandler_BridgeAuth_RejectsBridgeTokenIDMismatch(t *testing.T) {
 	}
 	defer conn.CloseNow()
 
-	if err := sendAuth(ctx, conn, env.makeBridgeToken("user1", "br_tokenBridge01"), "bridge", "br_messageBridge1"); err != nil {
+	if err := sendAuth(ctx, conn, env.makeBridgeToken("user1", "br_tokenBridge01"), "bridge", "br_tokenBridge01"); err != nil {
 		t.Fatalf("sendAuth bridge: %v", err)
 	}
 	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
@@ -754,10 +772,6 @@ func TestHandler_NotificationsClient_ForwardsBridgeID(t *testing.T) {
 		if got := r.Header.Get("X-Relay-Secret"); got != secret {
 			t.Errorf("expected X-Relay-Secret %q, got %q", secret, got)
 		}
-		if r.URL.Path == "/internal/bridge-token/validate" {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
 		var payload struct {
 			UserID   string `json:"userId"`
 			BridgeID string `json:"bridgeId"`
@@ -835,10 +849,6 @@ func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing
 		if got := r.Header.Get("X-Relay-Secret"); got != secret {
 			t.Errorf("expected X-Relay-Secret %q, got %q", secret, got)
 		}
-		if r.URL.Path == "/internal/bridge-token/validate" {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
 		var payload struct {
 			BridgeID string `json:"bridgeId"`
 			Status   string `json:"status"`
@@ -889,15 +899,15 @@ func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing
 	}
 }
 
-func TestHandler_BridgeAuth_RejectsAuthBackendBridgeTokenValidationFailure(t *testing.T) {
+// --- revocation enforcement: 404 on the connect-time status report closes
+// the bridge with CloseBridgeRevoked; everything else is fail-open ---
+
+func TestHandler_BridgeRevoked_ConnectReport404_ClosesWith4006(t *testing.T) {
 	const secret = "test-relay-secret"
 
 	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Relay-Secret"); got != secret {
 			t.Errorf("expected X-Relay-Secret %q, got %q", secret, got)
-		}
-		if r.URL.Path != "/internal/bridge-token/validate" {
-			t.Errorf("expected only bridge token validation before rejection, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -905,16 +915,78 @@ func TestHandler_BridgeAuth_RejectsAuthBackendBridgeTokenValidationFailure(t *te
 
 	notif := notifications.NewClient(notifServer.URL, secret)
 	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
-	ctx := context.Background()
 
-	conn, err := env.dial(ctx)
-	if err != nil {
-		t.Fatalf("dial bridge: %v", err)
-	}
+	conn := env.connectBridgeWithID(t, "user1", "br_revoked001")
 	defer conn.CloseNow()
 
-	if err := sendAuth(ctx, conn, env.makeBridgeToken("user1", "br_revoked001"), "bridge", "br_revoked001"); err != nil {
-		t.Fatalf("sendAuth bridge: %v", err)
+	expectClose(t, conn, websocket.StatusCode(protocol.CloseBridgeRevoked))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for env.relay.manager.Count() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("expected group cleanup after revoked close, got %d groups", env.relay.manager.Count())
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
+}
+
+func TestHandler_BridgeRevoked_ConnectReport5xx_FailOpen(t *testing.T) {
+	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(notifServer.Close)
+
+	notif := notifications.NewClient(notifServer.URL, "test-relay-secret")
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
+
+	conn := env.connectBridgeWithID(t, "user1", "br_abc12345")
+	defer conn.CloseNow()
+
+	time.Sleep(150 * time.Millisecond) // let the async status report complete
+
+	if env.relay.manager.Count() != 1 {
+		t.Fatalf("expected bridge to stay connected on 5xx, got %d groups", env.relay.manager.Count())
+	}
+	expectOpen(t, conn, 300*time.Millisecond)
+}
+
+func TestHandler_BridgeRevoked_ConnectReportTransportError_FailOpen(t *testing.T) {
+	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	unreachableURL := notifServer.URL
+	notifServer.Close()
+
+	notif := notifications.NewClient(unreachableURL, "test-relay-secret")
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
+
+	conn := env.connectBridgeWithID(t, "user1", "br_abc12345")
+	defer conn.CloseNow()
+
+	time.Sleep(150 * time.Millisecond) // let the async status report fail
+
+	if env.relay.manager.Count() != 1 {
+		t.Fatalf("expected bridge to stay connected on transport error, got %d groups", env.relay.manager.Count())
+	}
+	expectOpen(t, conn, 300*time.Millisecond)
+}
+
+func TestHandler_BridgeRevoked_LegacyNoBridgeID_404_FailOpen(t *testing.T) {
+	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(notifServer.Close)
+
+	notif := notifications.NewClient(notifServer.URL, "test-relay-secret")
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: false, notificationsClient: notif})
+
+	conn := env.connectBridgeNoID(t, "user1")
+	defer conn.CloseNow()
+
+	time.Sleep(150 * time.Millisecond) // let the async status report complete
+
+	if env.relay.manager.Count() != 1 {
+		t.Fatalf("expected legacy bridge to stay connected, got %d groups", env.relay.manager.Count())
+	}
+	expectOpen(t, conn, 300*time.Millisecond)
 }

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -657,6 +657,22 @@ func TestHandler_BridgeAuth_RejectsBridgeTokenIDMismatch(t *testing.T) {
 	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
 }
 
+func TestHandler_BridgeAuth_RejectsBridgeTokenWithoutBridgeID(t *testing.T) {
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
+	ctx := context.Background()
+
+	conn, err := env.dial(ctx)
+	if err != nil {
+		t.Fatalf("dial bridge: %v", err)
+	}
+	defer conn.CloseNow()
+
+	if err := sendAuth(ctx, conn, env.makeBridgeToken("user1", "br_tokenBridge01"), "bridge", ""); err != nil {
+		t.Fatalf("sendAuth bridge: %v", err)
+	}
+	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
+}
+
 func TestHandler_BridgeAuth_LegacyAllowedInTransition(t *testing.T) {
 	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
 
@@ -738,6 +754,10 @@ func TestHandler_NotificationsClient_ForwardsBridgeID(t *testing.T) {
 		if got := r.Header.Get("X-Relay-Secret"); got != secret {
 			t.Errorf("expected X-Relay-Secret %q, got %q", secret, got)
 		}
+		if r.URL.Path == "/internal/bridge-token/validate" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		var payload struct {
 			UserID   string `json:"userId"`
 			BridgeID string `json:"bridgeId"`
@@ -815,6 +835,10 @@ func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing
 		if got := r.Header.Get("X-Relay-Secret"); got != secret {
 			t.Errorf("expected X-Relay-Secret %q, got %q", secret, got)
 		}
+		if r.URL.Path == "/internal/bridge-token/validate" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		var payload struct {
 			BridgeID string `json:"bridgeId"`
 			Status   string `json:"status"`
@@ -863,4 +887,34 @@ func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing
 	if fourth.bridgeID != "br_newBridge01" || fourth.status != notifications.BridgeStatusDisconnected {
 		t.Fatalf("expected new bridge disconnected event, got %+v", fourth)
 	}
+}
+
+func TestHandler_BridgeAuth_RejectsAuthBackendBridgeTokenValidationFailure(t *testing.T) {
+	const secret = "test-relay-secret"
+
+	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Relay-Secret"); got != secret {
+			t.Errorf("expected X-Relay-Secret %q, got %q", secret, got)
+		}
+		if r.URL.Path != "/internal/bridge-token/validate" {
+			t.Errorf("expected only bridge token validation before rejection, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(notifServer.Close)
+
+	notif := notifications.NewClient(notifServer.URL, secret)
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
+	ctx := context.Background()
+
+	conn, err := env.dial(ctx)
+	if err != nil {
+		t.Fatalf("dial bridge: %v", err)
+	}
+	defer conn.CloseNow()
+
+	if err := sendAuth(ctx, conn, env.makeBridgeToken("user1", "br_revoked001"), "bridge", "br_revoked001"); err != nil {
+		t.Fatalf("sendAuth bridge: %v", err)
+	}
+	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
 }

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -564,11 +564,17 @@ func TestHandler_BridgeID_StoredOnConnection(t *testing.T) {
 	defer bridge.CloseNow()
 
 	g := env.relay.manager.GetOrCreateGroup("user1")
-	if g.Bridge == nil {
+	g.mu.Lock()
+	bridgeID := ""
+	if g.Bridge != nil {
+		bridgeID = g.Bridge.BridgeID
+	}
+	g.mu.Unlock()
+	if bridgeID == "" {
 		t.Fatal("expected bridge to be set on group")
 	}
-	if g.Bridge.BridgeID != "br_abc12345" {
-		t.Errorf("expected bridgeId br_abc12345 on connection, got %q", g.Bridge.BridgeID)
+	if bridgeID != "br_abc12345" {
+		t.Errorf("expected bridgeId br_abc12345 on connection, got %q", bridgeID)
 	}
 }
 

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -761,14 +761,22 @@ func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing
 	defer newBridge.CloseNow()
 	defer oldBridge.CloseNow()
 
-	second := readCaptured("new bridge connected")
-	if second.bridgeID != "br_newBridge01" || second.status != notifications.BridgeStatusConnected {
-		t.Fatalf("expected new bridge connected event, got %+v", second)
+	replacementEvents := []captured{
+		readCaptured("new bridge connected or old bridge disconnected"),
+		readCaptured("new bridge connected or old bridge disconnected"),
 	}
-
-	third := readCaptured("old bridge disconnected")
-	if third.bridgeID != "br_oldBridge01" || third.status != notifications.BridgeStatusDisconnected {
-		t.Fatalf("expected old bridge disconnected auth event, got %+v", third)
+	seenNewConnected := false
+	seenOldDisconnected := false
+	for _, event := range replacementEvents {
+		if event.bridgeID == "br_newBridge01" && event.status == notifications.BridgeStatusConnected {
+			seenNewConnected = true
+		}
+		if event.bridgeID == "br_oldBridge01" && event.status == notifications.BridgeStatusDisconnected {
+			seenOldDisconnected = true
+		}
+	}
+	if !seenNewConnected || !seenOldDisconnected {
+		t.Fatalf("expected new connected and old disconnected events, got %+v", replacementEvents)
 	}
 
 	newBridge.CloseNow()

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -29,7 +29,8 @@ type testEnv struct {
 }
 
 type testEnvOpts struct {
-	requireBridgeID bool
+	requireBridgeID     bool
+	notificationsClient *notifications.Client
 }
 
 func newTestEnv(t *testing.T, opts ...testEnvOpts) *testEnv {
@@ -62,7 +63,7 @@ func newTestEnv(t *testing.T, opts ...testEnvOpts) *testEnv {
 	}
 
 	jwtAuth := auth.NewJWTAuthenticator(ks)
-	relayServer := NewServer(":0", jwtAuth, nil, o.requireBridgeID)
+	relayServer := NewServer(":0", jwtAuth, o.notificationsClient, o.requireBridgeID)
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		relayServer.handleWebSocket(w, r)
@@ -653,21 +654,6 @@ func TestHandler_NotificationsClient_ForwardsBridgeID(t *testing.T) {
 		status   string
 	}
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("rsa.GenerateKey: %v", err)
-	}
-	pubDER, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
-	if err != nil {
-		t.Fatalf("MarshalPKIXPublicKey: %v", err)
-	}
-	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
-
-	keyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(pubPEM)
-	}))
-	t.Cleanup(keyServer.Close)
-
 	capturedCh := make(chan captured, 4)
 	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Relay-Secret"); got != secret {
@@ -689,43 +675,10 @@ func TestHandler_NotificationsClient_ForwardsBridgeID(t *testing.T) {
 	}))
 	t.Cleanup(notifServer.Close)
 
-	ks := auth.NewKeyStore(keyServer.URL)
-	if err := ks.Load(); err != nil {
-		t.Fatalf("KeyStore.Load: %v", err)
-	}
-	jwtAuth := auth.NewJWTAuthenticator(ks)
 	notif := notifications.NewClient(notifServer.URL, secret)
-	relayServer := NewServer(":0", jwtAuth, notif, true)
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
 
-	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		relayServer.handleWebSocket(w, r)
-	}))
-	t.Cleanup(httpSrv.Close)
-
-	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http") + "/"
-
-	claims := jwt.MapClaims{
-		"userId":    "user1",
-		"tokenType": "access",
-		"aud":       "mobile",
-		"iss":       "auth-backend",
-		"exp":       float64(time.Now().Add(time.Hour).Unix()),
-	}
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	signed, err := token.SignedString(privateKey)
-	if err != nil {
-		t.Fatalf("SignedString: %v", err)
-	}
-
-	conn, _, err := websocket.Dial(context.Background(), wsURL, nil)
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
-
-	authMsg := fmt.Sprintf(`{"type":"auth","token":"%s","role":"bridge","bridgeId":%q}`, signed, bridgeID)
-	if err := conn.Write(context.Background(), websocket.MessageText, []byte(authMsg)); err != nil {
-		t.Fatalf("write auth: %v", err)
-	}
+	conn := env.connectBridgeWithID(t, "user1", bridgeID)
 
 	select {
 	case c := <-capturedCh:
@@ -757,5 +710,67 @@ func TestHandler_NotificationsClient_ForwardsBridgeID(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for disconnected notification")
+	}
+}
+
+func TestHandler_BridgeReplacement_DoesNotNotifyDisconnectForOldBridge(t *testing.T) {
+	const secret = "test-relay-secret"
+
+	type captured struct {
+		bridgeID string
+		status   string
+	}
+
+	capturedCh := make(chan captured, 8)
+	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Relay-Secret"); got != secret {
+			t.Errorf("expected X-Relay-Secret %q, got %q", secret, got)
+		}
+		var payload struct {
+			BridgeID string `json:"bridgeId"`
+			Status   string `json:"status"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		capturedCh <- captured{bridgeID: payload.BridgeID, status: payload.Status}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(notifServer.Close)
+
+	notif := notifications.NewClient(notifServer.URL, secret)
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
+	oldBridge := env.connectBridgeWithID(t, "user1", "br_oldBridge01")
+
+	first := <-capturedCh
+	if first.bridgeID != "br_oldBridge01" || first.status != notifications.BridgeStatusConnected {
+		t.Fatalf("expected old bridge connected event, got %+v", first)
+	}
+
+	newBridge := env.connectBridgeWithID(t, "user1", "br_newBridge01")
+	defer newBridge.CloseNow()
+	defer oldBridge.CloseNow()
+
+	second := <-capturedCh
+	if second.bridgeID != "br_newBridge01" || second.status != notifications.BridgeStatusConnected {
+		t.Fatalf("expected new bridge connected event, got %+v", second)
+	}
+
+	select {
+	case event := <-capturedCh:
+		if event.bridgeID == "br_oldBridge01" && event.status == notifications.BridgeStatusDisconnected {
+			t.Fatalf("old bridge replacement must not emit disconnected event")
+		}
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	newBridge.CloseNow()
+	select {
+	case event := <-capturedCh:
+		if event.bridgeID != "br_newBridge01" || event.status != notifications.BridgeStatusDisconnected {
+			t.Fatalf("expected new bridge disconnected event, got %+v", event)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for new bridge disconnected notification")
 	}
 }

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -713,7 +713,7 @@ func TestHandler_NotificationsClient_ForwardsBridgeID(t *testing.T) {
 	}
 }
 
-func TestHandler_BridgeReplacement_DoesNotNotifyDisconnectForOldBridge(t *testing.T) {
+func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing.T) {
 	const secret = "test-relay-secret"
 
 	type captured struct {
@@ -722,6 +722,16 @@ func TestHandler_BridgeReplacement_DoesNotNotifyDisconnectForOldBridge(t *testin
 	}
 
 	capturedCh := make(chan captured, 8)
+	readCaptured := func(label string) captured {
+		t.Helper()
+		select {
+		case event := <-capturedCh:
+			return event
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %s notification", label)
+			return captured{}
+		}
+	}
 	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Relay-Secret"); got != secret {
 			t.Errorf("expected X-Relay-Secret %q, got %q", secret, got)
@@ -742,7 +752,7 @@ func TestHandler_BridgeReplacement_DoesNotNotifyDisconnectForOldBridge(t *testin
 	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
 	oldBridge := env.connectBridgeWithID(t, "user1", "br_oldBridge01")
 
-	first := <-capturedCh
+	first := readCaptured("old bridge connected")
 	if first.bridgeID != "br_oldBridge01" || first.status != notifications.BridgeStatusConnected {
 		t.Fatalf("expected old bridge connected event, got %+v", first)
 	}
@@ -751,26 +761,19 @@ func TestHandler_BridgeReplacement_DoesNotNotifyDisconnectForOldBridge(t *testin
 	defer newBridge.CloseNow()
 	defer oldBridge.CloseNow()
 
-	second := <-capturedCh
+	second := readCaptured("new bridge connected")
 	if second.bridgeID != "br_newBridge01" || second.status != notifications.BridgeStatusConnected {
 		t.Fatalf("expected new bridge connected event, got %+v", second)
 	}
 
-	select {
-	case event := <-capturedCh:
-		if event.bridgeID == "br_oldBridge01" && event.status == notifications.BridgeStatusDisconnected {
-			t.Fatalf("old bridge replacement must not emit disconnected event")
-		}
-	case <-time.After(150 * time.Millisecond):
+	third := readCaptured("old bridge disconnected")
+	if third.bridgeID != "br_oldBridge01" || third.status != notifications.BridgeStatusDisconnected {
+		t.Fatalf("expected old bridge disconnected auth event, got %+v", third)
 	}
 
 	newBridge.CloseNow()
-	select {
-	case event := <-capturedCh:
-		if event.bridgeID != "br_newBridge01" || event.status != notifications.BridgeStatusDisconnected {
-			t.Fatalf("expected new bridge disconnected event, got %+v", event)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for new bridge disconnected notification")
+	fourth := readCaptured("new bridge disconnected")
+	if fourth.bridgeID != "br_newBridge01" || fourth.status != notifications.BridgeStatusDisconnected {
+		t.Fatalf("expected new bridge disconnected event, got %+v", fourth)
 	}
 }

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -82,10 +82,31 @@ func (e *testEnv) wsURL() string {
 }
 
 func (e *testEnv) makeToken(userID string) string {
+	return e.makeAccessToken(userID)
+}
+
+func (e *testEnv) makeAccessToken(userID string) string {
 	claims := jwt.MapClaims{
 		"userId":    userID,
 		"tokenType": "access",
 		"aud":       "mobile",
+		"iss":       "auth-backend",
+		"exp":       float64(time.Now().Add(time.Hour).Unix()),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := token.SignedString(e.privateKey)
+	if err != nil {
+		panic(fmt.Sprintf("SignedString: %v", err))
+	}
+	return signed
+}
+
+func (e *testEnv) makeBridgeToken(userID, bridgeID string) string {
+	claims := jwt.MapClaims{
+		"userId":    userID,
+		"bridgeId":  bridgeID,
+		"tokenType": "bridge",
+		"aud":       "bridge",
 		"iss":       "auth-backend",
 		"exp":       float64(time.Now().Add(time.Hour).Unix()),
 	}
@@ -123,7 +144,11 @@ func (e *testEnv) connectBridgeWithID(t *testing.T, userID, bridgeID string) *we
 	if err != nil {
 		t.Fatalf("dial bridge: %v", err)
 	}
-	if err := sendAuth(ctx, conn, e.makeToken(userID), "bridge", bridgeID); err != nil {
+	token := e.makeAccessToken(userID)
+	if bridgeID != "" {
+		token = e.makeBridgeToken(userID, bridgeID)
+	}
+	if err := sendAuth(ctx, conn, token, "bridge", bridgeID); err != nil {
 		conn.CloseNow()
 		t.Fatalf("sendAuth bridge: %v", err)
 	}
@@ -600,6 +625,38 @@ func TestHandler_BridgeAuth_AcceptsBridgeID_PostTransition(t *testing.T) {
 	}
 }
 
+func TestHandler_BridgeAuth_RejectsAccessTokenWithBridgeID(t *testing.T) {
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
+	ctx := context.Background()
+
+	conn, err := env.dial(ctx)
+	if err != nil {
+		t.Fatalf("dial bridge: %v", err)
+	}
+	defer conn.CloseNow()
+
+	if err := sendAuth(ctx, conn, env.makeAccessToken("user1"), "bridge", "br_abc12345"); err != nil {
+		t.Fatalf("sendAuth bridge: %v", err)
+	}
+	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
+}
+
+func TestHandler_BridgeAuth_RejectsBridgeTokenIDMismatch(t *testing.T) {
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+	ctx := context.Background()
+
+	conn, err := env.dial(ctx)
+	if err != nil {
+		t.Fatalf("dial bridge: %v", err)
+	}
+	defer conn.CloseNow()
+
+	if err := sendAuth(ctx, conn, env.makeBridgeToken("user1", "br_tokenBridge01"), "bridge", "br_messageBridge1"); err != nil {
+		t.Fatalf("sendAuth bridge: %v", err)
+	}
+	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
+}
+
 func TestHandler_BridgeAuth_LegacyAllowedInTransition(t *testing.T) {
 	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
 
@@ -646,6 +703,22 @@ func TestHandler_PhoneAuth_IgnoresStrayBridgeID(t *testing.T) {
 	if m["type"] != "bridge_disconnected" {
 		t.Errorf("phone should be accepted; expected bridge_disconnected, got %q", m["type"])
 	}
+}
+
+func TestHandler_PhoneAuth_RejectsBridgeToken(t *testing.T) {
+	env := newTestEnv(t)
+	ctx := context.Background()
+
+	conn, err := env.dial(ctx)
+	if err != nil {
+		t.Fatalf("dial phone: %v", err)
+	}
+	defer conn.CloseNow()
+
+	if err := sendAuth(ctx, conn, env.makeBridgeToken("user1", "br_phoneBridge1"), "phone", ""); err != nil {
+		t.Fatalf("sendAuth phone: %v", err)
+	}
+	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
 }
 
 // --- end-to-end: bridgeId is forwarded in the /internal/bridge-status payload ---

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coder/websocket"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/sesori-ai/sesori_relay_server/internal/auth"
+	"github.com/sesori-ai/sesori_relay_server/internal/notifications"
 	"github.com/sesori-ai/sesori_relay_server/internal/protocol"
 )
 
@@ -27,8 +28,17 @@ type testEnv struct {
 	privateKey *rsa.PrivateKey
 }
 
-func newTestEnv(t *testing.T) *testEnv {
+type testEnvOpts struct {
+	requireBridgeID bool
+}
+
+func newTestEnv(t *testing.T, opts ...testEnvOpts) *testEnv {
 	t.Helper()
+
+	var o testEnvOpts
+	if len(opts) > 0 {
+		o = opts[0]
+	}
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -52,7 +62,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	}
 
 	jwtAuth := auth.NewJWTAuthenticator(ks)
-	relayServer := NewServer(":0", jwtAuth, nil)
+	relayServer := NewServer(":0", jwtAuth, nil, o.requireBridgeID)
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		relayServer.handleWebSocket(w, r)
@@ -91,24 +101,37 @@ func (e *testEnv) dial(ctx context.Context) (*websocket.Conn, error) {
 	return conn, err
 }
 
-func sendAuth(ctx context.Context, conn *websocket.Conn, token, role string) error {
-	msg := fmt.Sprintf(`{"type":"auth","token":"%s","role":"%s"}`, token, role)
+func sendAuth(ctx context.Context, conn *websocket.Conn, token, role, bridgeID string) error {
+	var msg string
+	if bridgeID == "" {
+		msg = fmt.Sprintf(`{"type":"auth","token":"%s","role":"%s"}`, token, role)
+	} else {
+		msg = fmt.Sprintf(`{"type":"auth","token":"%s","role":"%s","bridgeId":%q}`, token, role, bridgeID)
+	}
 	return conn.Write(ctx, websocket.MessageText, []byte(msg))
 }
 
 func (e *testEnv) connectBridge(t *testing.T, userID string) *websocket.Conn {
+	return e.connectBridgeWithID(t, userID, "br_defaultTest01")
+}
+
+func (e *testEnv) connectBridgeWithID(t *testing.T, userID, bridgeID string) *websocket.Conn {
 	t.Helper()
 	ctx := context.Background()
 	conn, err := e.dial(ctx)
 	if err != nil {
 		t.Fatalf("dial bridge: %v", err)
 	}
-	if err := sendAuth(ctx, conn, e.makeToken(userID), "bridge"); err != nil {
+	if err := sendAuth(ctx, conn, e.makeToken(userID), "bridge", bridgeID); err != nil {
 		conn.CloseNow()
 		t.Fatalf("sendAuth bridge: %v", err)
 	}
 	time.Sleep(60 * time.Millisecond)
 	return conn
+}
+
+func (e *testEnv) connectBridgeNoID(t *testing.T, userID string) *websocket.Conn {
+	return e.connectBridgeWithID(t, userID, "")
 }
 
 func (e *testEnv) connectPhone(t *testing.T, userID string) (*websocket.Conn, []byte) {
@@ -118,7 +141,7 @@ func (e *testEnv) connectPhone(t *testing.T, userID string) (*websocket.Conn, []
 	if err != nil {
 		t.Fatalf("dial phone: %v", err)
 	}
-	if err := sendAuth(ctx, conn, e.makeToken(userID), "phone"); err != nil {
+	if err := sendAuth(ctx, conn, e.makeToken(userID), "phone", ""); err != nil {
 		conn.CloseNow()
 		t.Fatalf("sendAuth phone: %v", err)
 	}
@@ -341,7 +364,7 @@ func TestHandler_PhoneCap(t *testing.T) {
 	}
 	defer conn6.CloseNow()
 
-	if err := sendAuth(context.Background(), conn6, env.makeToken("user1"), "phone"); err != nil {
+	if err := sendAuth(context.Background(), conn6, env.makeToken("user1"), "phone", ""); err != nil {
 		t.Fatalf("sendAuth 6th phone: %v", err)
 	}
 	expectClose(t, conn6, websocket.StatusCode(protocol.CloseAccountFull))
@@ -530,5 +553,209 @@ func TestBinaryFraming_PhonePrepend(t *testing.T) {
 	}
 	if string(framed[2:]) != string(payload) {
 		t.Errorf("expected payload %q after prefix", payload)
+	}
+}
+
+func TestHandler_BridgeID_StoredOnConnection(t *testing.T) {
+	env := newTestEnv(t)
+
+	bridge := env.connectBridgeWithID(t, "user1", "br_abc12345")
+	defer bridge.CloseNow()
+
+	g := env.relay.manager.GetOrCreateGroup("user1")
+	if g.Bridge == nil {
+		t.Fatal("expected bridge to be set on group")
+	}
+	if g.Bridge.BridgeID != "br_abc12345" {
+		t.Errorf("expected bridgeId br_abc12345 on connection, got %q", g.Bridge.BridgeID)
+	}
+}
+
+func TestHandler_BridgeAuth_RequiresBridgeID_PostTransition(t *testing.T) {
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+
+	bridge := env.connectBridgeNoID(t, "user1")
+	expectClose(t, bridge, websocket.StatusCode(protocol.CloseAuthFailure))
+
+	if env.relay.manager.Count() != 0 {
+		t.Errorf("expected 0 groups (rejected), got %d", env.relay.manager.Count())
+	}
+}
+
+func TestHandler_BridgeAuth_AcceptsBridgeID_PostTransition(t *testing.T) {
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+
+	bridge := env.connectBridgeWithID(t, "user1", "br_abc12345")
+	defer bridge.CloseNow()
+
+	if env.relay.manager.Count() != 1 {
+		t.Errorf("expected 1 group, got %d", env.relay.manager.Count())
+	}
+}
+
+func TestHandler_BridgeAuth_LegacyAllowedInTransition(t *testing.T) {
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
+
+	bridge := env.connectBridgeNoID(t, "user1")
+	defer bridge.CloseNow()
+
+	if env.relay.manager.Count() != 1 {
+		t.Errorf("expected 1 group (legacy accepted in transition), got %d", env.relay.manager.Count())
+	}
+}
+
+func TestHandler_BridgeAuth_InvalidBridgeID_Format(t *testing.T) {
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
+
+	bridge := env.connectBridgeWithID(t, "user1", "not-a-valid-bridge-id")
+	expectClose(t, bridge, websocket.StatusCode(protocol.CloseAuthFailure))
+}
+
+func TestHandler_BridgeAuth_InvalidBridgeID_FormatPostTransition(t *testing.T) {
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+
+	bridge := env.connectBridgeWithID(t, "user1", "br_short")
+	expectClose(t, bridge, websocket.StatusCode(protocol.CloseAuthFailure))
+}
+
+func TestHandler_PhoneAuth_IgnoresStrayBridgeID(t *testing.T) {
+	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+
+	ctx := context.Background()
+	conn, err := env.dial(ctx)
+	if err != nil {
+		t.Fatalf("dial phone: %v", err)
+	}
+	defer conn.CloseNow()
+
+	token := env.makeToken("user1")
+	msg := fmt.Sprintf(`{"type":"auth","token":"%s","role":"phone","bridgeId":"br_strayValue"}`, token)
+	if err := conn.Write(ctx, websocket.MessageText, []byte(msg)); err != nil {
+		t.Fatalf("sendAuth: %v", err)
+	}
+
+	firstMsg := readTextMsg(t, conn, 2*time.Second)
+	m := parseJSON(t, firstMsg)
+	if m["type"] != "bridge_disconnected" {
+		t.Errorf("phone should be accepted; expected bridge_disconnected, got %q", m["type"])
+	}
+}
+
+// --- end-to-end: bridgeId is forwarded in the /internal/bridge-status payload ---
+
+func TestHandler_NotificationsClient_ForwardsBridgeID(t *testing.T) {
+	const secret = "test-relay-secret"
+	const bridgeID = "br_endToEnd1234"
+
+	type captured struct {
+		userID   string
+		bridgeID string
+		status   string
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	keyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(pubPEM)
+	}))
+	t.Cleanup(keyServer.Close)
+
+	capturedCh := make(chan captured, 4)
+	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Relay-Secret"); got != secret {
+			t.Errorf("expected X-Relay-Secret %q, got %q", secret, got)
+		}
+		var payload struct {
+			UserID   string `json:"userId"`
+			BridgeID string `json:"bridgeId"`
+			Status   string `json:"status"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		select {
+		case capturedCh <- captured{userID: payload.UserID, bridgeID: payload.BridgeID, status: payload.Status}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(notifServer.Close)
+
+	ks := auth.NewKeyStore(keyServer.URL)
+	if err := ks.Load(); err != nil {
+		t.Fatalf("KeyStore.Load: %v", err)
+	}
+	jwtAuth := auth.NewJWTAuthenticator(ks)
+	notif := notifications.NewClient(notifServer.URL, secret)
+	relayServer := NewServer(":0", jwtAuth, notif, true)
+
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		relayServer.handleWebSocket(w, r)
+	}))
+	t.Cleanup(httpSrv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http") + "/"
+
+	claims := jwt.MapClaims{
+		"userId":    "user1",
+		"tokenType": "access",
+		"aud":       "mobile",
+		"iss":       "auth-backend",
+		"exp":       float64(time.Now().Add(time.Hour).Unix()),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+
+	conn, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	authMsg := fmt.Sprintf(`{"type":"auth","token":"%s","role":"bridge","bridgeId":%q}`, signed, bridgeID)
+	if err := conn.Write(context.Background(), websocket.MessageText, []byte(authMsg)); err != nil {
+		t.Fatalf("write auth: %v", err)
+	}
+
+	select {
+	case c := <-capturedCh:
+		if c.userID != "user1" {
+			t.Errorf("expected userId user1, got %q", c.userID)
+		}
+		if c.bridgeID != bridgeID {
+			t.Errorf("expected bridgeId %q, got %q", bridgeID, c.bridgeID)
+		}
+		if c.status != notifications.BridgeStatusConnected {
+			t.Errorf("expected status connected, got %q", c.status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for connected notification")
+	}
+
+	conn.CloseNow()
+
+	select {
+	case c := <-capturedCh:
+		if c.userID != "user1" {
+			t.Errorf("expected userId user1, got %q", c.userID)
+		}
+		if c.bridgeID != bridgeID {
+			t.Errorf("expected bridgeId %q, got %q", bridgeID, c.bridgeID)
+		}
+		if c.status != notifications.BridgeStatusDisconnected {
+			t.Errorf("expected status disconnected, got %q", c.status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for disconnected notification")
 	}
 }

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -13,22 +13,27 @@ import (
 // Server is the relay WebSocket server. It manages rooms, rate limiting, and
 // delegates authentication to the provided Authenticator (nil = auth disabled).
 type Server struct {
-	addr          string
-	manager       *GroupManager
-	rateLimiter   *RateLimiter
-	httpServer    *http.Server
-	jwtAuth       *auth.JWTAuthenticator
-	notifications *notifications.Client
+	addr            string
+	manager         *GroupManager
+	rateLimiter     *RateLimiter
+	httpServer      *http.Server
+	jwtAuth         *auth.JWTAuthenticator
+	notifications   *notifications.Client
+	requireBridgeID bool
 }
 
 // NewServer creates a relay server. Pass a nil authenticator to disable auth.
-func NewServer(addr string, jwtAuth *auth.JWTAuthenticator, notifs *notifications.Client) *Server {
+// requireBridgeID enforces that every bridge connection sends a bridgeId in
+// its auth message; when false, bridges without bridgeId are accepted (legacy
+// path) and no bridgeId is forwarded to the auth server.
+func NewServer(addr string, jwtAuth *auth.JWTAuthenticator, notifs *notifications.Client, requireBridgeID bool) *Server {
 	return &Server{
-		addr:          addr,
-		manager:       NewGroupManager(),
-		rateLimiter:   NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
-		jwtAuth:       jwtAuth,
-		notifications: notifs,
+		addr:            addr,
+		manager:         NewGroupManager(),
+		rateLimiter:     NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
+		jwtAuth:         jwtAuth,
+		notifications:   notifs,
+		requireBridgeID: requireBridgeID,
 	}
 }
 


### PR DESCRIPTION
## Summary

Carries a per-bridge-instance identifier (`bridgeId`) from the bridge CLI through the relay to the auth server's `POST /internal/bridge-status` webhook, so the auth server can attribute connection-state changes to a specific bridge instance instead of just a userId.

**Design note (revised after review):** an earlier revision required bridge-scoped JWTs and validated them against auth via a synchronous `POST /internal/bridge-token/validate` call on every bridge connect. That is gone: bridges (like phones) authenticate with the **user access token**, verified locally — an auth-server outage cannot refuse the bridge fleet. The relay does not validate `bridgeId` ownership; it forwards it.

## Wire change

`RoleAuthMessage` gains an optional `bridgeId` field:

```json
{ "type": "auth", "token": "<user access JWT>", "role": "bridge", "bridgeId": "br_abc123" }
```

Format: `^br_[A-Za-z0-9_-]{8,32}$` (same as the auth server). Ignored for `role: "phone"`. Token validation now accepts **only** `tokenType: "access"` / `aud: "mobile"` for both roles (bridge-typed tokens were never minted in production).

## Revocation at reconnect, fail-open

New close code **4006 `CloseBridgeRevoked`**: when the connect-time `/internal/bridge-status` report returns an explicit HTTP 404 (unknown/revoked bridgeId) and the connection presented a `bridgeId`, the relay closes that bridge connection with 4006. The bridge client reacts by re-registering. Transport errors, timeouts, and 5xx are **fail-open** (log only) — no availability coupling on the auth server. Legacy no-bridgeId connections are never closed by this path.

## Configuration

`RELAY_REQUIRE_BRIDGE_ID` / `--require-bridge-id` (default `false`): when `false`, bridges without `bridgeId` are accepted with a warning (legacy path); when `true`, they are rejected with `CloseAuthFailure`. Malformed bridgeIds are rejected in both modes. Companion flag on auth: `AUTH_REQUIRE_BRIDGE_ID_IN_STATUS`; both flip together after the bridge fleet rolls over.

## Out of scope

The relay still enforces 1 bridge per account (a second bridge replaces the first). Multi-bridge routing is a follow-up.

## Companion PRs

- sesori-ai/sesori_auth_server#28 — bridges collection, idempotent `POST /auth/bridges`, `/auth/me bridges[]`, bridge-status 404 semantics
- sesori-ai/sesori_apps_monorepo#215 — bridge client registration + 4006 handling

## Tests

`go build` / `go vet` / `go test` / `go test -race` all clean. New coverage: access token + bridgeId accepted; bridge-typed tokens rejected for both roles; 404 on connect-report closes with 4006 (incl. group cleanup); 5xx and transport errors fail open; legacy no-bridgeId 404 fails open.