### PR TITLE
feat: close displaced bridge with dedicated 4007 code

### DIFF
--- a/internal/protocol/closecodes.go
+++ b/internal/protocol/closecodes.go
@@ -7,4 +7,12 @@ const (
 	CloseRoomNotFound  = 4004
 	CloseAccountFull   = 4005
 	CloseBridgeRevoked = 4006
+	// CloseBridgeReplaced is sent to a bridge that is displaced when another
+	// bridge for the same account connects and takes the single bridge slot.
+	// A dedicated code (rather than a plain 1000 normal close with a "replaced"
+	// reason) lets the displaced bridge recognise the takeover reliably: close
+	// reason strings are fragile (intermediaries may strip/rewrite them) while
+	// codes survive. The displaced bridge reconnects only on a long backoff so
+	// two always-on bridges don't tight-loop kicking each other.
+	CloseBridgeReplaced = 4007
 )

--- a/internal/relay/account_group.go
+++ b/internal/relay/account_group.go
@@ -54,6 +54,36 @@ func (g *AccountGroup) AllPhones() []*Connection {
 	return phones
 }
 
+// PhonesIfCurrentBridge atomically snapshots all phone connections, but only if
+// bridge is still this group's current bridge. A bridge displaced by a newer
+// connection gets nil, so its read loop can never fan a frame out to phones —
+// the current-bridge check and the target selection happen under one lock hold,
+// leaving no window where a stale bridge could pass the check and then relay.
+func (g *AccountGroup) PhonesIfCurrentBridge(bridge *Connection) []*Connection {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.Bridge != bridge {
+		return nil
+	}
+	phones := make([]*Connection, 0, len(g.Phones))
+	for _, p := range g.Phones {
+		phones = append(phones, p)
+	}
+	return phones
+}
+
+// PhoneIfCurrentBridge atomically returns the phone with connID, but only if
+// bridge is still this group's current bridge (nil otherwise). Same TOCTOU-free
+// guarantee as PhonesIfCurrentBridge for the unicast routing path.
+func (g *AccountGroup) PhoneIfCurrentBridge(bridge *Connection, connID uint16) *Connection {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.Bridge != bridge {
+		return nil
+	}
+	return g.Phones[connID]
+}
+
 // IsEmpty returns true if the group has no bridge and no phone connections.
 func (g *AccountGroup) IsEmpty() bool {
 	g.mu.Lock()

--- a/internal/relay/account_group.go
+++ b/internal/relay/account_group.go
@@ -54,11 +54,19 @@ func (g *AccountGroup) AllPhones() []*Connection {
 	return phones
 }
 
-// PhonesIfCurrentBridge atomically snapshots all phone connections, but only if
-// bridge is still this group's current bridge. A bridge displaced by a newer
-// connection gets nil, so its read loop can never fan a frame out to phones —
-// the current-bridge check and the target selection happen under one lock hold,
-// leaving no window where a stale bridge could pass the check and then relay.
+// PhonesIfCurrentBridge snapshots all phone connections, but only if bridge is
+// still this group's current bridge (nil otherwise) — the current-bridge check
+// and the target selection happen under one lock hold. This drops all frames
+// from a bridge that was already displaced before it routes them.
+//
+// It does NOT hold the lock across the caller's subsequent websocket writes
+// (that would serialize all relay traffic on socket I/O), so a bridge that is
+// current at snapshot time but displaced microseconds later can still deliver
+// the single frame it is mid-routing. That residual frame is one the bridge
+// read while it was the active bridge, so delivering it during handover is
+// benign — indistinguishable from a frame sent just before the swap. Closing
+// that last window would require writing under the group lock, which is not
+// worth the contention.
 func (g *AccountGroup) PhonesIfCurrentBridge(bridge *Connection) []*Connection {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -72,9 +80,10 @@ func (g *AccountGroup) PhonesIfCurrentBridge(bridge *Connection) []*Connection {
 	return phones
 }
 
-// PhoneIfCurrentBridge atomically returns the phone with connID, but only if
-// bridge is still this group's current bridge (nil otherwise). Same TOCTOU-free
-// guarantee as PhonesIfCurrentBridge for the unicast routing path.
+// PhoneIfCurrentBridge returns the phone with connID, but only if bridge is
+// still this group's current bridge (nil otherwise). Same narrowed-window
+// characterization as PhonesIfCurrentBridge for the unicast routing path: the
+// check + lookup are atomic, but the caller's write is not under the lock.
 func (g *AccountGroup) PhoneIfCurrentBridge(bridge *Connection, connID uint16) *Connection {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/internal/relay/account_group_test.go
+++ b/internal/relay/account_group_test.go
@@ -175,6 +175,32 @@ func TestGroupManager_RemoveGroupIfEmpty_NonExistent(t *testing.T) {
 	}
 }
 
+func TestGroupManager_HasLiveBridgeWithID(t *testing.T) {
+	m := NewGroupManager()
+
+	// No group / no bridge yet.
+	if m.HasLiveBridgeWithID("user1", "br_x") {
+		t.Error("expected false with no group")
+	}
+
+	g := m.GetOrCreateGroup("user1")
+	if m.HasLiveBridgeWithID("user1", "br_x") {
+		t.Error("expected false with no bridge")
+	}
+
+	g.Bridge = &Connection{BridgeID: "br_x"}
+	if !m.HasLiveBridgeWithID("user1", "br_x") {
+		t.Error("expected true for the live bridge id")
+	}
+	if m.HasLiveBridgeWithID("user1", "br_y") {
+		t.Error("expected false for a different bridge id")
+	}
+	// An empty bridgeId (legacy) is never matched.
+	if m.HasLiveBridgeWithID("user1", "") {
+		t.Error("expected false for an empty bridge id")
+	}
+}
+
 // A stale handler whose cleanup runs late must not delete a fresh group that a
 // newer connection created for the same user after the stale handler's group
 // was already removed.

--- a/internal/relay/account_group_test.go
+++ b/internal/relay/account_group_test.go
@@ -129,7 +129,7 @@ func TestGroupManager_RemoveGroupIfEmpty_WithBridge(t *testing.T) {
 
 	g.Bridge = &Connection{}
 
-	m.RemoveGroupIfEmpty("user1")
+	m.RemoveGroupIfEmpty("user1", g)
 
 	if m.Count() != 1 {
 		t.Errorf("group with bridge should not be removed, count=%d", m.Count())
@@ -142,7 +142,7 @@ func TestGroupManager_RemoveGroupIfEmpty_WithPhone(t *testing.T) {
 
 	g.Phones[1] = &Connection{}
 
-	m.RemoveGroupIfEmpty("user1")
+	m.RemoveGroupIfEmpty("user1", g)
 
 	if m.Count() != 1 {
 		t.Errorf("group with phone should not be removed, count=%d", m.Count())
@@ -151,14 +151,14 @@ func TestGroupManager_RemoveGroupIfEmpty_WithPhone(t *testing.T) {
 
 func TestGroupManager_RemoveGroupIfEmpty_Empty(t *testing.T) {
 	m := NewGroupManager()
-	m.GetOrCreateGroup("user1")
+	g1 := m.GetOrCreateGroup("user1")
 	m.GetOrCreateGroup("user2")
 
 	if m.Count() != 2 {
 		t.Fatalf("expected count 2, got %d", m.Count())
 	}
 
-	m.RemoveGroupIfEmpty("user1")
+	m.RemoveGroupIfEmpty("user1", g1)
 
 	if m.Count() != 1 {
 		t.Errorf("empty group should be removed, count=%d", m.Count())
@@ -168,26 +168,53 @@ func TestGroupManager_RemoveGroupIfEmpty_Empty(t *testing.T) {
 func TestGroupManager_RemoveGroupIfEmpty_NonExistent(t *testing.T) {
 	m := NewGroupManager()
 
-	m.RemoveGroupIfEmpty("nonexistent")
+	m.RemoveGroupIfEmpty("nonexistent", NewAccountGroup("nonexistent"))
 
 	if m.Count() != 0 {
 		t.Errorf("expected count 0, got %d", m.Count())
 	}
 }
 
+// A stale handler whose cleanup runs late must not delete a fresh group that a
+// newer connection created for the same user after the stale handler's group
+// was already removed.
+func TestGroupManager_RemoveGroupIfEmpty_DoesNotRemoveRecreatedGroup(t *testing.T) {
+	m := NewGroupManager()
+	stale := m.GetOrCreateGroup("user1")
+
+	// The stale group is removed (empty), then a fresh group is created for the
+	// same user and gains a live bridge.
+	m.RemoveGroupIfEmpty("user1", stale)
+	fresh := m.GetOrCreateGroup("user1")
+	if fresh == stale {
+		t.Fatal("expected a distinct fresh group instance")
+	}
+
+	// The stale handler's late cleanup for the SAME userID must be a no-op: it
+	// does not own the fresh group instance.
+	m.RemoveGroupIfEmpty("user1", stale)
+
+	if m.Count() != 1 {
+		t.Errorf("fresh group must survive a stale handler's cleanup, count=%d", m.Count())
+	}
+	if got := m.GetOrCreateGroup("user1"); got != fresh {
+		t.Error("fresh group instance must remain registered for the user")
+	}
+}
+
 func TestGroupManager_Count_ReflectsRemovals(t *testing.T) {
 	m := NewGroupManager()
 
-	m.GetOrCreateGroup("a")
-	m.GetOrCreateGroup("b")
+	ga := m.GetOrCreateGroup("a")
+	gb := m.GetOrCreateGroup("b")
 	m.GetOrCreateGroup("c")
 
 	if m.Count() != 3 {
 		t.Fatalf("expected 3, got %d", m.Count())
 	}
 
-	m.RemoveGroupIfEmpty("a")
-	m.RemoveGroupIfEmpty("b")
+	m.RemoveGroupIfEmpty("a", ga)
+	m.RemoveGroupIfEmpty("b", gb)
 
 	if m.Count() != 1 {
 		t.Errorf("expected 1 after two removals, got %d", m.Count())

--- a/internal/relay/group_manager.go
+++ b/internal/relay/group_manager.go
@@ -48,3 +48,24 @@ func (m *GroupManager) Count() int {
 	defer m.mu.RUnlock()
 	return len(m.groups)
 }
+
+// HasLiveBridgeWithID reports whether the user's currently-registered group has
+// a live bridge with bridgeID. A displaced handler uses this before emitting a
+// stale BridgeStatusDisconnected: if a fresh connection already re-registered
+// the same bridgeId (possibly in a recreated group), the old handler's late
+// teardown must not mark that live bridge offline in the auth server. bridgeID
+// must be non-empty (legacy bridges without an id are never matched).
+func (m *GroupManager) HasLiveBridgeWithID(userID, bridgeID string) bool {
+	if bridgeID == "" {
+		return false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	g, ok := m.groups[userID]
+	if !ok {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.Bridge != nil && g.Bridge.BridgeID == bridgeID
+}

--- a/internal/relay/group_manager.go
+++ b/internal/relay/group_manager.go
@@ -26,11 +26,17 @@ func (m *GroupManager) GetOrCreateGroup(userID string) *AccountGroup {
 	return g
 }
 
-func (m *GroupManager) RemoveGroupIfEmpty(userID string) {
+// RemoveGroupIfEmpty deletes group from the manager only if it is still the
+// current group instance registered for userID AND it is empty. Passing the
+// caller's own group instance (rather than deleting by userID key alone) makes
+// cleanup safe against group recreation: a stale handler whose teardown runs
+// late must not delete a fresh group that a newer connection created for the
+// same user in the meantime.
+func (m *GroupManager) RemoveGroupIfEmpty(userID string, group *AccountGroup) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if g, ok := m.groups[userID]; ok {
+	if g, ok := m.groups[userID]; ok && g == group {
 		if g.IsEmpty() {
 			delete(m.groups, userID)
 		}

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -157,32 +157,34 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 
 	if oldBridge != nil {
 		// Displace the old bridge with the dedicated takeover close code so the
-		// displaced bridge can recognise the takeover and back off instead of
-		// tight-looping. Three properties matter here:
-		//   1. The close frame carries CloseBridgeReplaced. Conn.Close is a
-		//      compare-and-swap on the connection's closing state: whoever
-		//      closes first wins. If we cancelled the old read loop first, its
-		//      ctx-cancel teardown would win the CAS and drop the socket
-		//      abnormally (EOF), so the displaced bridge would never see 4007.
-		//      Close therefore runs (and wins the CAS + writes the frame)
-		//      before Cancel.
-		//   2. Conn.Close does not block this new bridge's connect flow: it
-		//      writes the frame then waits up to 5s for the peer's close reply
-		//      (holding the read lock), so it runs off the hot path in a
-		//      goroutine.
-		//   3. The old bridge's own teardown (phone bridge_disconnected +
-		//      disconnect notification) must not wait out that 5s handshake.
-		//      Cancel the old connection's context on a short delay: 100ms is
-		//      ample for Close to win the CAS and flush the close frame to the
-		//      socket, after which the cancel unblocks the old read loop so its
-		//      teardown fires promptly instead of after the handshake timeout.
+		// displaced bridge recognises the takeover and backs off instead of
+		// tight-looping. Correctness rests on a strict order — Close, then
+		// Cancel — run off the hot path in one goroutine:
+		//
+		//   * Close wins the close CAS and writes the CloseBridgeReplaced frame
+		//     synchronously (writeClose runs before the handshake wait), so the
+		//     displaced bridge reliably observes 4007. Cancelling first would
+		//     instead let the old read loop's ctx-cancel teardown / handler
+		//     return close the socket abnormally (EOF) and race the frame away.
+		//   * While Close then waits for the peer's close reply it HOLDS the
+		//     connection read lock, so the old bridge's read loop is parked and
+		//     cannot forward any stale frame to phones after group.Bridge was
+		//     swapped — the takeover window is closed without a separate guard.
+		//   * Cancel runs after Close returns to release the old connection
+		//     context (ping loop, deferred cleanup). It is not on this new
+		//     bridge's connect path (the whole block is a goroutine), so a
+		//     slow/non-responsive displaced peer only delays that bridge's own
+		//     disconnect bookkeeping up to the handshake timeout — a best-effort
+		//     lag, never a correctness issue, and phones already learned of the
+		//     new bridge via the bridge_connected writes below.
+		//
 		// Keep the "replaced" reason as a rollout fallback the bridge can match
 		// on until it keys purely on CloseBridgeReplaced; the code is
 		// authoritative.
 		go func() {
 			_ = oldBridge.Conn.Close(websocket.StatusCode(protocol.CloseBridgeReplaced), "replaced")
+			oldBridge.Cancel()
 		}()
-		time.AfterFunc(100*time.Millisecond, oldBridge.Cancel)
 	}
 
 	for _, phone := range phones {

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -264,13 +264,17 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		payload := data[2:]
 
 		// Enforce the single-active-bridge invariant on every frame: a bridge
-		// displaced by a newer connection for this account must never relay to
+		// displaced by a newer connection for this account must not relay to
 		// phones, even for frames it had already queued/read before its close
 		// completes. The current-bridge check is folded into the same locked
 		// target selection (PhonesIfCurrentBridge / PhoneIfCurrentBridge), so a
-		// bridge that stops being current between reading a frame and routing it
-		// gets no targets — no TOCTOU window, and no reliance on the displaced
-		// connection's close/cancel racing the read loop.
+		// bridge displaced before it routes a frame gets no targets — without
+		// relying on the displaced connection's close/cancel racing the read
+		// loop. The lock is not held across the writes below (that would
+		// serialize all relay traffic on socket I/O), so a bridge displaced in
+		// the microseconds between snapshot and write can still deliver the one
+		// frame it is mid-routing; that frame was read while it was the active
+		// bridge, so its late arrival during handover is benign.
 		if connID == 0 {
 			for _, target := range group.PhonesIfCurrentBridge(newConn) {
 				_ = target.Conn.Write(ctx, websocket.MessageBinary, payload)

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -261,6 +261,18 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		connID := binary.BigEndian.Uint16(data[:2])
 		payload := data[2:]
 
+		// Enforce the single-active-bridge invariant on every frame: a bridge
+		// displaced by a newer connection for this account must never relay to
+		// phones, even for frames it had already queued/read before its close
+		// completes. This guard is timing-independent — it does not rely on the
+		// displaced connection's close/cancel racing the read loop.
+		group.mu.Lock()
+		isCurrentBridge := group.Bridge == newConn
+		group.mu.Unlock()
+		if !isCurrentBridge {
+			continue
+		}
+
 		if connID == 0 {
 			targets := group.AllPhones()
 			for _, target := range targets {

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -166,10 +166,6 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		//     displaced bridge reliably observes 4007. Cancelling first would
 		//     instead let the old read loop's ctx-cancel teardown / handler
 		//     return close the socket abnormally (EOF) and race the frame away.
-		//   * While Close then waits for the peer's close reply it HOLDS the
-		//     connection read lock, so the old bridge's read loop is parked and
-		//     cannot forward any stale frame to phones after group.Bridge was
-		//     swapped — the takeover window is closed without a separate guard.
 		//   * Cancel runs after Close returns to release the old connection
 		//     context (ping loop, deferred cleanup). It is not on this new
 		//     bridge's connect path (the whole block is a goroutine), so a
@@ -177,6 +173,12 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		//     disconnect bookkeeping up to the handshake timeout — a best-effort
 		//     lag, never a correctness issue, and phones already learned of the
 		//     new bridge via the bridge_connected writes below.
+		//
+		// The single-active-bridge invariant does NOT depend on this close
+		// timing: the read loop's PhonesIfCurrentBridge / PhoneIfCurrentBridge
+		// routing (see below) drops any frame from a bridge that is no longer
+		// group.Bridge, so a displaced bridge can never relay even in the window
+		// before its close/cancel lands.
 		//
 		// Keep the "replaced" reason as a rollout fallback the bridge can match
 		// on until it keys purely on CloseBridgeReplaced; the code is
@@ -264,26 +266,19 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		// Enforce the single-active-bridge invariant on every frame: a bridge
 		// displaced by a newer connection for this account must never relay to
 		// phones, even for frames it had already queued/read before its close
-		// completes. This guard is timing-independent — it does not rely on the
-		// displaced connection's close/cancel racing the read loop.
-		group.mu.Lock()
-		isCurrentBridge := group.Bridge == newConn
-		group.mu.Unlock()
-		if !isCurrentBridge {
-			continue
-		}
-
+		// completes. The current-bridge check is folded into the same locked
+		// target selection (PhonesIfCurrentBridge / PhoneIfCurrentBridge), so a
+		// bridge that stops being current between reading a frame and routing it
+		// gets no targets — no TOCTOU window, and no reliance on the displaced
+		// connection's close/cancel racing the read loop.
 		if connID == 0 {
-			targets := group.AllPhones()
-			for _, target := range targets {
+			for _, target := range group.PhonesIfCurrentBridge(newConn) {
 				_ = target.Conn.Write(ctx, websocket.MessageBinary, payload)
 			}
 			continue
 		}
 
-		group.mu.Lock()
-		target := group.Phones[connID]
-		group.mu.Unlock()
+		target := group.PhoneIfCurrentBridge(newConn, connID)
 		if target == nil {
 			continue
 		}

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -73,13 +73,13 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	slog.Debug("connection joined group", "userID", userID, "role", authMsg.Role)
 	if authMsg.Role == protocol.RoleBridge {
 		if authMsg.BridgeID != "" && !bridgeIDRegexp.MatchString(authMsg.BridgeID) {
-			s.manager.RemoveGroupIfEmpty(userID)
+			s.manager.RemoveGroupIfEmpty(userID, group)
 			slog.Warn("bridge connection rejected: invalid bridgeId format", "userId", userID, "bridgeId", authMsg.BridgeID)
 			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid bridgeId format")
 			return
 		}
 		if s.requireBridgeID && authMsg.BridgeID == "" {
-			s.manager.RemoveGroupIfEmpty(userID)
+			s.manager.RemoveGroupIfEmpty(userID, group)
 			slog.Warn("bridge connection rejected: bridgeId required", "userId", userID)
 			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridgeId required")
 			return
@@ -244,7 +244,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 			}()
 		}
 
-		manager.RemoveGroupIfEmpty(userID)
+		manager.RemoveGroupIfEmpty(userID, group)
 	}()
 
 	conn.SetReadLimit(maxMessageSize)
@@ -349,7 +349,7 @@ func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup,
 			}
 			_ = bridge.Conn.Write(ctx, websocket.MessageText, phoneDisconnMsg)
 		}
-		manager.RemoveGroupIfEmpty(userID)
+		manager.RemoveGroupIfEmpty(userID, group)
 	}()
 
 	conn.SetReadLimit(maxMessageSize)

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -156,8 +156,30 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 	phones := group.AllPhones()
 
 	if oldBridge != nil {
-		oldBridge.Cancel()
-		_ = oldBridge.Conn.Close(websocket.StatusNormalClosure, "replaced")
+		// Displace the old bridge with the dedicated takeover close code so the
+		// displaced bridge can recognise the takeover and back off instead of
+		// tight-looping. Two properties matter here:
+		//   1. The close frame carries CloseBridgeReplaced. Conn.Close is a
+		//      compare-and-swap on the connection's closing state: whoever
+		//      closes first wins. If we cancelled the old read loop first, its
+		//      ctx-cancel teardown would win the CAS and drop the socket
+		//      abnormally (EOF), so the displaced bridge would never see 4007.
+		//      Close therefore runs before Cancel and writes the clean frame.
+		//   2. Neither operation blocks this new bridge's own connect flow.
+		//      Conn.Close writes the frame then waits up to 5s for the peer's
+		//      close reply (holding the read lock), which also stalls the old
+		//      bridge goroutine's own disconnect bookkeeping. Run it off the hot
+		//      path in a goroutine, and cancel the old connection's context
+		//      concurrently so its read loop unblocks and its teardown
+		//      (phone bridge_disconnected + disconnect notification) fires
+		//      promptly rather than after the handshake timeout.
+		// Keep the "replaced" reason as a rollout fallback the bridge can match
+		// on until it keys purely on CloseBridgeReplaced; the code is
+		// authoritative.
+		go func() {
+			_ = oldBridge.Conn.Close(websocket.StatusCode(protocol.CloseBridgeReplaced), "replaced")
+			oldBridge.Cancel()
+		}()
 	}
 
 	for _, phone := range phones {

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -229,6 +229,16 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		group.mu.Unlock()
 		shouldNotifyDisconnected := isCurrent || (bridgeID != "" && bridgeID != currentBridgeID)
 
+		// Suppress the disconnect notification if this bridgeId is already live
+		// again on the user's current group: a displaced handler whose teardown
+		// runs late (widened by the Close-then-Cancel ordering) must not mark a
+		// freshly-reconnected bridge with the same id offline in the auth server
+		// after its connected notification. This checks the manager's current
+		// registration, not this handler's own (possibly stale) group.
+		if shouldNotifyDisconnected && manager.HasLiveBridgeWithID(userID, bridgeID) {
+			shouldNotifyDisconnected = false
+		}
+
 		if isCurrent {
 			phones := group.AllPhones()
 			for _, phone := range phones {

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -158,28 +158,31 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 	if oldBridge != nil {
 		// Displace the old bridge with the dedicated takeover close code so the
 		// displaced bridge can recognise the takeover and back off instead of
-		// tight-looping. Two properties matter here:
+		// tight-looping. Three properties matter here:
 		//   1. The close frame carries CloseBridgeReplaced. Conn.Close is a
 		//      compare-and-swap on the connection's closing state: whoever
 		//      closes first wins. If we cancelled the old read loop first, its
 		//      ctx-cancel teardown would win the CAS and drop the socket
 		//      abnormally (EOF), so the displaced bridge would never see 4007.
-		//      Close therefore runs before Cancel and writes the clean frame.
-		//   2. Neither operation blocks this new bridge's own connect flow.
-		//      Conn.Close writes the frame then waits up to 5s for the peer's
-		//      close reply (holding the read lock), which also stalls the old
-		//      bridge goroutine's own disconnect bookkeeping. Run it off the hot
-		//      path in a goroutine, and cancel the old connection's context
-		//      concurrently so its read loop unblocks and its teardown
-		//      (phone bridge_disconnected + disconnect notification) fires
-		//      promptly rather than after the handshake timeout.
+		//      Close therefore runs (and wins the CAS + writes the frame)
+		//      before Cancel.
+		//   2. Conn.Close does not block this new bridge's connect flow: it
+		//      writes the frame then waits up to 5s for the peer's close reply
+		//      (holding the read lock), so it runs off the hot path in a
+		//      goroutine.
+		//   3. The old bridge's own teardown (phone bridge_disconnected +
+		//      disconnect notification) must not wait out that 5s handshake.
+		//      Cancel the old connection's context on a short delay: 100ms is
+		//      ample for Close to win the CAS and flush the close frame to the
+		//      socket, after which the cancel unblocks the old read loop so its
+		//      teardown fires promptly instead of after the handshake timeout.
 		// Keep the "replaced" reason as a rollout fallback the bridge can match
 		// on until it keys purely on CloseBridgeReplaced; the code is
 		// authoritative.
 		go func() {
 			_ = oldBridge.Conn.Close(websocket.StatusCode(protocol.CloseBridgeReplaced), "replaced")
-			oldBridge.Cancel()
 		}()
+		time.AfterFunc(100*time.Millisecond, oldBridge.Cancel)
 	}
 
 	for _, phone := range phones {

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -355,6 +355,44 @@ func TestHandler_BridgeReplacement(t *testing.T) {
 	}
 }
 
+// A bridge displaced by a newer connection must not relay frames to phones,
+// even a frame it managed to send before its close completed — the read-loop
+// single-active-bridge guard drops it regardless of close/cancel timing.
+func TestHandler_DisplacedBridgeDoesNotRelayToPhones(t *testing.T) {
+	env := newTestEnv(t)
+	ctx := context.Background()
+
+	bridge1 := env.connectBridge(t, "user1")
+	defer bridge1.CloseNow()
+
+	phone, _ := env.connectPhone(t, "user1")
+	defer phone.CloseNow()
+	readTextMsg(t, bridge1, 2*time.Second) // phone_connected on bridge1
+
+	// Displace bridge1. Immediately try to relay a frame from the now-stale
+	// bridge before it has observed its close. (bridge2 receives no
+	// phone_connected: the phone was already connected before the replacement.)
+	bridge2 := env.connectBridge(t, "user1")
+	defer bridge2.CloseNow()
+
+	payload := []byte("stale-broadcast")
+	frame := append([]byte{0x00, 0x00}, payload...)
+	// Best-effort: the write may fail if the close already landed; either way
+	// the read-loop single-active-bridge guard must drop it.
+	_ = bridge1.Write(ctx, websocket.MessageBinary, frame)
+
+	// The phone legitimately receives a bridge_connected text notice for the
+	// new bridge. Assert exactly that (a text frame, not the stale binary one):
+	// if the guard failed, this read would instead surface the binary payload.
+	notice := readTextMsg(t, phone, 2*time.Second)
+	nm := parseJSON(t, notice)
+	if nm["type"] != "bridge_connected" {
+		t.Errorf("phone expected bridge_connected, got %q", nm["type"])
+	}
+	// And no stale binary frame follows it.
+	expectNoMsg(t, phone, 500*time.Millisecond)
+}
+
 func TestHandler_PhoneNoBridge(t *testing.T) {
 	env := newTestEnv(t)
 

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -876,18 +876,6 @@ func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing
 	defer newBridge.CloseNow()
 	defer oldBridge.CloseNow()
 
-	// A real displaced bridge keeps reading, so it observes and replies to the
-	// server's CloseBridgeReplaced frame, completing the close handshake
-	// promptly. Drain the old bridge here so the server's close does not sit in
-	// its handshake-wait timeout (which would delay the disconnect bookkeeping).
-	go func() {
-		for {
-			if _, _, err := oldBridge.Read(context.Background()); err != nil {
-				return
-			}
-		}
-	}()
-
 	replacementEvents := []captured{
 		readCaptured("new bridge connected or old bridge disconnected"),
 		readCaptured("new bridge connected or old bridge disconnected"),

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -876,6 +876,19 @@ func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing
 	defer newBridge.CloseNow()
 	defer oldBridge.CloseNow()
 
+	// A real displaced bridge keeps reading, so it observes and replies to the
+	// server's CloseBridgeReplaced frame, completing the close handshake
+	// promptly (which then unblocks the old connection's teardown). Drain the
+	// old bridge here so the server's close does not sit out its full
+	// handshake-wait timeout waiting on an unresponsive peer.
+	go func() {
+		for {
+			if _, _, err := oldBridge.Read(context.Background()); err != nil {
+				return
+			}
+		}
+	}()
+
 	replacementEvents := []captured{
 		readCaptured("new bridge connected or old bridge disconnected"),
 		readCaptured("new bridge connected or old bridge disconnected"),

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -346,7 +346,9 @@ func TestHandler_BridgeReplacement(t *testing.T) {
 	bridge2 := env.connectBridge(t, "user1")
 	defer bridge2.CloseNow()
 
-	expectAnyClose(t, bridge1)
+	// A displaced bridge is closed with the dedicated CloseBridgeReplaced code
+	// so it can recognise the takeover and back off instead of tight-looping.
+	expectClose(t, bridge1, websocket.StatusCode(protocol.CloseBridgeReplaced))
 
 	if env.relay.manager.Count() != 1 {
 		t.Errorf("expected 1 group after replacement, got %d", env.relay.manager.Count())
@@ -873,6 +875,18 @@ func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing
 	newBridge := env.connectBridgeWithID(t, "user1", "br_newBridge01")
 	defer newBridge.CloseNow()
 	defer oldBridge.CloseNow()
+
+	// A real displaced bridge keeps reading, so it observes and replies to the
+	// server's CloseBridgeReplaced frame, completing the close handshake
+	// promptly. Drain the old bridge here so the server's close does not sit in
+	// its handshake-wait timeout (which would delay the disconnect bookkeeping).
+	go func() {
+		for {
+			if _, _, err := oldBridge.Read(context.Background()); err != nil {
+				return
+			}
+		}
+	}()
 
 	replacementEvents := []captured{
 		readCaptured("new bridge connected or old bridge disconnected"),


### PR DESCRIPTION
## What

When a second bridge for the same account connects and takes the single relay bridge slot, close the **displaced** bridge with a dedicated `CloseBridgeReplaced` (`4007`) close code instead of a plain `1000` normal close with a `"replaced"` reason.

## Why

The relay holds one bridge slot per account and closes the displaced bridge on contact. Today it uses `1000 + reason "replaced"`, which the bridge treats as a generic drop and reconnects on a backoff that resets to 1s — so two always-on bridges (two desktops, or a desktop + a forgotten `systemd` bridge) mutually kick each other forever while phones see `bridge_connected` flapping.

Close **reason strings are fragile** — intermediaries/proxies may strip or rewrite them — while close **codes survive**, and the relay already keys close semantics on codes (`CloseBridgeRevoked = 4006` precedent). A dedicated `4007` code lets the displaced bridge recognise the takeover reliably and back off on a **long backoff** instead of tight-looping.

The `"replaced"` reason is kept as a **rollout fallback** the bridge matches on until it keys purely on the code.

## How

- `internal/protocol/closecodes.go`: add `CloseBridgeReplaced = 4007`.
- `internal/relay/handler.go`: in the bridge-replacement path, write the `4007` close frame **before** cancelling the old connection's context (so it wins the connection's close CAS and the displaced bridge reliably observes the code, not an abnormal EOF), off the new bridge's hot path so the new connect flow isn't stalled.

## Deploy ordering (important)

This is the tracked **prerequisite** for the Sesori bridge PR that adds `RelayCloseCodes.bridgeReplaced = 4007` + the takeover backoff policy (desktop plan ADR A22). **This relay change must be merged AND deployed to the production relay before the bridge half merges.** The bridge keeps the `1000/"replaced"` fallback so an older relay never breaks it during the rollout window.

## Tests

- `TestHandler_BridgeReplacement` now asserts the displaced bridge is closed with exactly `CloseBridgeReplaced` (was `expectAnyClose`).
- `TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected` drains the old bridge so it completes the close handshake, mirroring a real displaced client.
- Full suite green under `go test -race ./...`; `go vet` and `gofmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close displaced bridges with dedicated `4007` to make takeovers reliable, enforce single-active-bridge at routing time, harden group cleanup to avoid deleting a freshly recreated group, and suppress stale disconnects when the same `bridgeId` is live again. Close is ordered (Close then Cancel) off the new bridge’s hot path; one in-flight frame read while active may still land.

- **New Features**
  - Added `CloseBridgeReplaced = 4007`; send it to the old bridge, then `Cancel` its context after `Close` returns in a goroutine; keep reason "replaced" as a rollout fallback.
  - Enforced single-active-bridge by folding the current-bridge check into target selection via `PhonesIfCurrentBridge`/`PhoneIfCurrentBridge`, dropping frames from displaced connections regardless of close timing; tests verify displaced bridges don’t relay.
  - Hardened group cleanup: `GroupManager.RemoveGroupIfEmpty(userID, group)` now deletes only if `group` is still the registered instance and empty; handler calls updated and a regression test ensures a stale handler can’t remove a recreated group.
  - Suppressed stale bridge-disconnect: added `GroupManager.HasLiveBridgeWithID(userID, bridgeID)` and check it before emitting a disconnect so a late teardown doesn’t mark a same-`bridgeId` live bridge offline.

- **Migration**
  - Deploy this relay change to production before releasing the bridge update that keys on `4007`.
  - During rollout, older relays still use `1000`/"replaced" and bridges remain compatible.

<sup>Written for commit 6eee828d95ba3fd97d032d931641468bb216d91e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_relay_server/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

