### PR TITLE
docs: record accepted best-effort 4007 delivery tradeoff at takeover

### DIFF
--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -42,7 +42,7 @@ type KeyExchangeMessage struct {
 type RoleAuthMessage struct {
 	Type     string `json:"type"` // "auth"
 	Token    string `json:"token"`
-	Role     string `json:"role"` // "bridge" or "phone"
+	Role     string `json:"role"`               // "bridge" or "phone"
 	BridgeID string `json:"bridgeId,omitempty"` // optional; bridge role only. Format: ^br_[A-Za-z0-9_-]{8,32}$. Required when the relay runs with --require-bridge-id.
 }
 

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -163,9 +163,10 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		//
 		//   * Close wins the close CAS and writes the CloseBridgeReplaced frame
 		//     synchronously (writeClose runs before the handshake wait), so the
-		//     displaced bridge reliably observes 4007. Cancelling first would
-		//     instead let the old read loop's ctx-cancel teardown / handler
-		//     return close the socket abnormally (EOF) and race the frame away.
+		//     displaced bridge observes 4007 on the common path. Cancelling
+		//     first would instead let the old read loop's ctx-cancel teardown /
+		//     handler return close the socket abnormally (EOF) and race the
+		//     frame away.
 		//   * Cancel runs after Close returns to release the old connection
 		//     context (ping loop, deferred cleanup). It is not on this new
 		//     bridge's connect path (the whole block is a goroutine), so a
@@ -173,6 +174,20 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		//     disconnect bookkeeping up to the handshake timeout — a best-effort
 		//     lag, never a correctness issue, and phones already learned of the
 		//     new bridge via the bridge_connected writes below.
+		//
+		// 4007 delivery is deliberately best-effort (accepted tradeoff, PR #7):
+		// the close frame contends for the connection's frame-write mutex with
+		// any in-flight phone→bridge write (handlePhone), so if the displaced
+		// bridge stalls its reads while such a write is blocked, the close
+		// write can time out (~5s) and drop the TCP connection without
+		// delivering 4007 — the displaced bridge then sees an abnormal close
+		// (1006) and retries on its normal backoff instead of the takeover
+		// backoff. coder/websocket offers no way to preempt the in-flight
+		// write: cancelling its context hard-closes the whole connection
+		// (timeoutLoop -> close), which loses 4007 anyway. The miss is
+		// self-limiting — the reconnected bridge is displaced again, almost
+		// certainly with no write in flight, and observes 4007 then — so it
+		// degrades to at most one extra reconnect, not a reconnect war.
 		//
 		// The single-active-bridge invariant does NOT depend on this close
 		// timing: the read loop's PhonesIfCurrentBridge / PhoneIfCurrentBridge


### PR DESCRIPTION
## Summary

Follow-up to #7 (relay half of desktop-plan ADR A22). PR #7 left two reviewer threads deliberately unresolved for a decision on whether to harden the displaced-bridge close path further. This PR records the decision: **both are accepted as won't-fix**, and the code comment that overstated the guarantee is corrected.

### Decisions (with verification)

**1. `4007` close starved by an in-flight phone→bridge write** (#7 [r3528688134](https://github.com/sesori-ai/sesori_relay_server/pull/7#discussion_r3528688134)) — **accepted as won't-fix.**
- Verified against `coder/websocket` v1.8.12 source: the close frame goes through `writeControl` → `writeFrame`, contending on the same `writeFrameMu` as data writes, with a 5s timeout (write.go:233-246). Starvation by a blocked large write is real.
- The suggested fix (preempt in-flight writes) is **not achievable with this library**: cancelling an in-flight write's context makes `timeoutLoop` hard-close the whole TCP connection (conn.go:181-186) — which loses `4007` anyway, i.e. the cure is the disease. Anything else is a hot-path redesign (per-connection write queues / message fragmentation) that is disproportionate to the edge.
- Impact of a miss is bounded: correctness never depends on `4007` (the read-loop `PhonesIfCurrentBridge`/`PhoneIfCurrentBridge` guard drops stale frames regardless), and the miss self-limits — the reconnected bridge is displaced again, almost certainly with no write in flight, and observes `4007` then. At most one extra reconnect, not a war.

**2. Residual one-frame send window at the handover instant** (#7 [r3528502201](https://github.com/sesori-ai/sesori_relay_server/pull/7#discussion_r3528502201)) — **accepted as won't-fix.**
- The leaked frame is one the displaced bridge read **while it was the active bridge**; its delivery during handover is indistinguishable from delivery just before the swap.
- Closing the window requires holding `group.mu` across websocket writes (with 64 MiB max messages, that head-of-line-blocks an entire account group on one slow socket) or a per-phone write-queue redesign. Worse than the symptom. The comments on `PhonesIfCurrentBridge`/`PhoneIfCurrentBridge` already describe this window honestly (added in #7) — no change needed there.

### Changes
- `internal/relay/handler.go` — the displacement comment claimed the displaced bridge *"reliably observes 4007"*, which overstated the guarantee and contradicted accepted tradeoff (1). Corrected to "on the common path" and documented the best-effort semantics, the library constraint, and the self-limiting behaviour where the next reader will look.
- `internal/protocol/messages.go` — gofmt (comment alignment left unformatted by #6).

**No behavior change.** Docs/format only.

## Testing
- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test -race ./...` green, including the three #7 regression tests (`TestHandler_DisplacedBridgeDoesNotRelayToPhones`, `TestGroupManager_RemoveGroupIfEmpty_DoesNotRemoveRecreatedGroup`, `TestGroupManager_HasLiveBridgeWithID`)

## Related
- Companion PR sesori-ai/sesori_apps_monorepo#385 (bridge half) is green/mergeable and remains gated only on this repo's prod deploy of #7.
- Both #7 threads will be closed as resolved with a final reply referencing this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the accepted best-effort delivery of `4007` close frames during bridge takeover and correct an overstated guarantee; no behavior change. Also run gofmt to align a comment in `internal/protocol/messages.go`.

<sup>Written for commit b119388b8d5762314b8659b804187f59a60a04a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_relay_server/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

