### PR TITLE
fix: rate limit relay by trusted client IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 *.gitkeep
 .env
 .sisyphus/
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ internal/
     ├── handler.go             WebSocket upgrade + auth handshake + message routing
     ├── server.go              HTTP server, /health endpoint, connection lifecycle
     ├── account_group.go       Per-userId group: 1 bridge + up to 5 phones, connId assignment
-    └── rate_limiter.go        Per-IP connection limiting (max 10), global group cap (10,000)
+    └── rate_limiter.go        Per-IP connection limiting (max 20), global group cap (10,000)
 ```
 
 ## WHERE TO LOOK
@@ -29,7 +29,7 @@ internal/
 | Change auth/JWT | `internal/auth/` | RS256 verification, claims in authenticator.go |
 | Modify protocol messages | `internal/protocol/messages.go` | JSON control messages (bridge/phone connected/disconnected) |
 | Change binary framing | `internal/protocol/framing.go` | 2-byte connId prefix on binary frames |
-| Adjust rate limits | `internal/relay/rate_limiter.go` | Per-IP (10) and global group (10,000) caps |
+| Adjust rate limits | `internal/relay/rate_limiter.go` | Per-IP (20) and global group (10,000) caps |
 | Add endpoints | `internal/relay/server.go` | HTTP mux, currently /health and /ws |
 | Modify group behavior | `internal/relay/account_group.go` | Max 5 phones per account, connId=0 broadcast |
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -143,7 +143,7 @@ curl http://localhost:8080/health
 
 At `info` level, the relay logs aggregate connection statistics every 10
 minutes: active WebSockets, distinct resolved client IPs, the busiest IP
-bucket, and active account groups.
+bucket, cumulative rejected connection attempts, and active account groups.
 
 To verify client-IP extraction after a Cloudflare deployment:
 
@@ -157,7 +157,8 @@ To verify client-IP extraction after a Cloudflare deployment:
    the ingress proxy.
 4. Confirm the startup record contains `trust-cf-connecting-ip=true` and the
    10-minute `relay connection stats` records show a plausible
-   `activeClientIPs` count rather than one shared proxy bucket.
+   `activeClientIPs` count rather than one shared proxy bucket. The
+   `rejectedConnections` field is cumulative since process start.
 5. Restore `LOG_LEVEL=info` after verification because debug records contain
    client IP addresses.
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -113,6 +113,7 @@ For self-hosted deployments on a VPS (AWS EC2, DigitalOcean, Linode, etc.).
 ### Environment Variables
 
 - `LOG_LEVEL` — Logging level: `debug`, `info`, `warn`, `error` (default: `info`)
+- `RELAY_TRUST_CF_CONNECTING_IP` — Set to `true` only when every request passes through Cloudflare and direct access to the origin is blocked. Uses Cloudflare's single-IP `CF-Connecting-IP` header for per-client connection limits instead of the ingress proxy address.
 
 ### Command-Line Flags
 
@@ -120,6 +121,7 @@ The relay server accepts the following flags:
 
 - `--addr` — Listen address (default: `:8080`)
 - `--log-level` — Logging level (overrides `LOG_LEVEL` env var)
+- `--trust-cf-connecting-ip` — Trust `CF-Connecting-IP` for per-client connection limits. This is the flag equivalent of `RELAY_TRUST_CF_CONNECTING_IP=true`.
 
 ### Example: Custom Port
 
@@ -138,6 +140,26 @@ curl http://localhost:8080/health
 ```
 
 ### Logs
+
+At `info` level, the relay logs aggregate connection statistics every 10
+minutes: active WebSockets, distinct resolved client IPs, the busiest IP
+bucket, and active account groups.
+
+To verify client-IP extraction after a Cloudflare deployment:
+
+1. Set `RELAY_TRUST_CF_CONNECTING_IP=true` and temporarily set
+   `LOG_LEVEL=debug`.
+2. Connect from two different public networks, such as Wi-Fi and phone
+   cellular data.
+3. Inspect `websocket client IP resolved` records. `source` must be
+   `cf-connecting-ip`; `clientIP` should match each network's public address
+   and vary between the two networks, while `peerIP` may repeat because it is
+   the ingress proxy.
+4. Confirm the startup record contains `trust-cf-connecting-ip=true` and the
+   10-minute `relay connection stats` records show a plausible
+   `activeClientIPs` count rather than one shared proxy bucket.
+5. Restore `LOG_LEVEL=info` after verification because debug records contain
+   client IP addresses.
 
 **Docker Compose:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Phone ←──(encrypted)──→ Relay Server ←──(encrypted)──→ B
 ```
 
 - **Account groups**: Connections are grouped by `userId` from the JWT. Each group holds 1 bridge + up to 5 phones.
-- **Rate limiting**: Max 10 connections per IP, max 10,000 active groups globally.
+- **Rate limiting**: Max 20 connections per resolved client IP, max 10,000 active groups globally.
 - **No storage**: The relay holds no state beyond active WebSocket connections. Nothing is persisted.
 
 ## Running locally
@@ -42,6 +42,7 @@ The server listens on `:8080` by default.
 | `--addr` | `RELAY_ADDR` | `:8080` | Listen address |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
 | `--require-bridge-id` | `RELAY_REQUIRE_BRIDGE_ID` | `false` | Require `bridgeId` field on bridge auth messages. Default `false` accepts legacy bridges (no `bridgeId`) and logs a warning. Set `true` to enforce after the bridge fleet has rolled over. |
+| `--trust-cf-connecting-ip` | `RELAY_TRUST_CF_CONNECTING_IP` | `false` | Use Cloudflare's validated `CF-Connecting-IP` value for per-IP limits. Enable only when every request reaches the relay through Cloudflare and direct origin access is blocked. |
 
 ## Endpoints
 
@@ -75,7 +76,7 @@ The GitHub Actions workflows run on every push and PR:
 
 - The relay **cannot decrypt** any traffic. All data between phone and bridge is encrypted with XChaCha20-Poly1305 using keys derived from an X25519 key exchange that happens directly between the two peers.
 - JWT authentication is required before any data is forwarded. Tokens must be RS256-signed with valid `userId`, `tokenType`, `aud`, `iss`, and `exp` claims.
-- Rate limiting prevents abuse: max connections per IP, max groups globally, and at most 5 phones per account group.
+- Rate limiting prevents abuse: max 20 connections per resolved client IP, max groups globally, and at most 5 phones per account group.
 - The server runs as a non-root user in Docker.
 
 ## Protocol

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -24,6 +24,11 @@ func main() {
 	authBackendURL := flag.String("auth-backend-url", "", "auth backend base URL (e.g. https://auth.example.com); auth is disabled when empty")
 	relayWebhookSecret := flag.String("relay-webhook-secret", "", "shared secret for auth server webhook")
 	requireBridgeID := flag.Bool("require-bridge-id", false, "require bridgeId field on bridge auth messages (transition gate; set true once the bridge fleet has rolled over)")
+	trustCFConnectingIP := flag.Bool(
+		"trust-cf-connecting-ip",
+		false,
+		"trust Cloudflare's CF-Connecting-IP header (enable only when all traffic passes through Cloudflare)",
+	)
 	flag.Parse()
 
 	// Also honour the AUTH_BACKEND_URL environment variable (flag takes precedence).
@@ -33,6 +38,11 @@ func main() {
 	if *relayWebhookSecret == "" {
 		*relayWebhookSecret = os.Getenv("RELAY_WEBHOOK_SECRET")
 	}
+	if !flagWasSet("log-level") {
+		if value := os.Getenv("LOG_LEVEL"); value != "" {
+			*logLevel = value
+		}
+	}
 	if !flagWasSet("require-bridge-id") {
 		v, ok, err := envBool("RELAY_REQUIRE_BRIDGE_ID")
 		if err != nil {
@@ -41,6 +51,16 @@ func main() {
 		}
 		if ok {
 			*requireBridgeID = v
+		}
+	}
+	if !flagWasSet("trust-cf-connecting-ip") {
+		v, ok, err := envBool("RELAY_TRUST_CF_CONNECTING_IP")
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "invalid RELAY_TRUST_CF_CONNECTING_IP: %v\n", err)
+			os.Exit(1)
+		}
+		if ok {
+			*trustCFConnectingIP = v
 		}
 	}
 
@@ -56,7 +76,13 @@ func main() {
 		slog.Info("auth disabled (no --auth-backend-url provided)")
 	}
 
-	slog.Info("starting relay server", "addr", *addr, "log-level", *logLevel, "require-bridge-id", *requireBridgeID)
+	slog.Info(
+		"starting relay server",
+		"addr", *addr,
+		"log-level", *logLevel,
+		"require-bridge-id", *requireBridgeID,
+		"trust-cf-connecting-ip", *trustCFConnectingIP,
+	)
 
 	var authenticator *auth.JWTAuthenticator
 	if *authBackendURL != "" {
@@ -77,7 +103,7 @@ func main() {
 		slog.Info("push notifications disabled (no webhook secret)")
 	}
 
-	server := relay.NewServer(*addr, authenticator, notifs, *requireBridgeID)
+	server := relay.NewServer(*addr, authenticator, notifs, *requireBridgeID, *trustCFConnectingIP)
 
 	if err := server.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.Error("server error", "err", err)

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -97,13 +97,6 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		"source", string(clientIP.source),
 	)
 	if !s.rateLimiter.AllowConnection(ip) {
-		slog.Warn(
-			"websocket connection rejected: per-IP limit reached",
-			"clientIP", clientIP.address,
-			"peerIP", clientIP.peerAddress,
-			"source", string(clientIP.source),
-			"limit", s.rateLimiter.maxPerIP,
-		)
 		http.Error(w, "too many connections", http.StatusTooManyRequests)
 		return
 	}

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -8,7 +8,9 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/coder/websocket"
@@ -18,10 +20,24 @@ import (
 )
 
 const (
-	maxMessageSize      = 64 * 1024 * 1024 // 64 MiB — session data can be large
-	maxPhonesPerAccount = 5
-	pingInterval        = 30 * time.Second
+	maxMessageSize       = 64 * 1024 * 1024 // 64 MiB — session data can be large
+	maxPhonesPerAccount  = 5
+	pingInterval         = 30 * time.Second
+	cfConnectingIPHeader = "CF-Connecting-IP"
 )
+
+type clientIPSource string
+
+const (
+	clientIPSourceRemoteAddr     clientIPSource = "remote-addr"
+	clientIPSourceCFConnectingIP clientIPSource = "cf-connecting-ip"
+)
+
+type clientIPInfo struct {
+	address     string
+	peerAddress string
+	source      clientIPSource
+}
 
 var bridgeIDRegexp = regexp.MustCompile(`^br_[A-Za-z0-9_-]{8,32}$`)
 
@@ -30,17 +46,64 @@ var (
 	bridgeDisconnectedJSON, _ = json.Marshal(protocol.BridgeDisconnectedMessage{Type: protocol.TypeBridgeDisconnected})
 )
 
-func getClientIP(r *http.Request) string {
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
+func resolveClientIP(r *http.Request, trustCFConnectingIP bool) clientIPInfo {
+	peerAddress := remoteIPAddress(r.RemoteAddr)
+	if trustCFConnectingIP {
+		values := r.Header.Values(cfConnectingIPHeader)
+		if len(values) == 1 {
+			if address, ok := canonicalIPAddress(values[0]); ok {
+				return clientIPInfo{
+					address:     address,
+					peerAddress: peerAddress,
+					source:      clientIPSourceCFConnectingIP,
+				}
+			}
+		}
 	}
-	return ip
+
+	return clientIPInfo{
+		address:     peerAddress,
+		peerAddress: peerAddress,
+		source:      clientIPSourceRemoteAddr,
+	}
+}
+
+func remoteIPAddress(remoteAddr string) string {
+	value := strings.TrimSpace(remoteAddr)
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		value = host
+	}
+	if address, ok := canonicalIPAddress(value); ok {
+		return address
+	}
+	return value
+}
+
+func canonicalIPAddress(value string) (string, bool) {
+	address, err := netip.ParseAddr(strings.TrimSpace(value))
+	if err != nil {
+		return "", false
+	}
+	return address.Unmap().String(), true
 }
 
 func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
-	ip := getClientIP(r)
+	clientIP := resolveClientIP(r, s.trustCFConnectingIP)
+	ip := clientIP.address
+	slog.Debug(
+		"websocket client IP resolved",
+		"clientIP", clientIP.address,
+		"peerIP", clientIP.peerAddress,
+		"source", string(clientIP.source),
+	)
 	if !s.rateLimiter.AllowConnection(ip) {
+		slog.Warn(
+			"websocket connection rejected: per-IP limit reached",
+			"clientIP", clientIP.address,
+			"peerIP", clientIP.peerAddress,
+			"source", string(clientIP.source),
+			"limit", s.rateLimiter.maxPerIP,
+		)
 		http.Error(w, "too many connections", http.StatusTooManyRequests)
 		return
 	}

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -187,6 +187,9 @@ func TestHandleWebSocketRateLimitsByTrustedCloudflareIP(t *testing.T) {
 	if response.Code != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want %d", response.Code, http.StatusTooManyRequests)
 	}
+	if got := server.rateLimiter.ConnectionStats().RejectedConnections; got != 1 {
+		t.Fatalf("rejected connections = %d, want 1", got)
+	}
 }
 
 func (e *testEnv) wsURL() string {

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -31,6 +31,7 @@ type testEnv struct {
 type testEnvOpts struct {
 	requireBridgeID     bool
 	notificationsClient *notifications.Client
+	trustCFConnectingIP bool
 }
 
 func newTestEnv(t *testing.T, opts ...testEnvOpts) *testEnv {
@@ -63,7 +64,7 @@ func newTestEnv(t *testing.T, opts ...testEnvOpts) *testEnv {
 	}
 
 	jwtAuth := auth.NewJWTAuthenticator(ks)
-	relayServer := NewServer(":0", jwtAuth, o.notificationsClient, o.requireBridgeID)
+	relayServer := NewServer(":0", jwtAuth, o.notificationsClient, o.requireBridgeID, o.trustCFConnectingIP)
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		relayServer.handleWebSocket(w, r)
@@ -74,6 +75,117 @@ func newTestEnv(t *testing.T, opts ...testEnvOpts) *testEnv {
 		relay:      relayServer,
 		httpServer: httpSrv,
 		privateKey: privateKey,
+	}
+}
+
+func TestResolveClientIP(t *testing.T) {
+	tests := []struct {
+		name                string
+		remoteAddr          string
+		cfConnectingIP      []string
+		trustCFConnectingIP bool
+		wantAddress         string
+		wantPeerAddress     string
+		wantSource          clientIPSource
+	}{
+		{
+			name:                "ignores spoofed header when trust is disabled",
+			remoteAddr:          "10.0.0.7:4312",
+			cfConnectingIP:      []string{"198.51.100.44"},
+			trustCFConnectingIP: false,
+			wantAddress:         "10.0.0.7",
+			wantPeerAddress:     "10.0.0.7",
+			wantSource:          clientIPSourceRemoteAddr,
+		},
+		{
+			name:                "uses trusted Cloudflare IPv4 address",
+			remoteAddr:          "10.0.0.7:4312",
+			cfConnectingIP:      []string{"198.51.100.44"},
+			trustCFConnectingIP: true,
+			wantAddress:         "198.51.100.44",
+			wantPeerAddress:     "10.0.0.7",
+			wantSource:          clientIPSourceCFConnectingIP,
+		},
+		{
+			name:                "canonicalizes trusted Cloudflare IPv6 address",
+			remoteAddr:          "[2001:db8::2]:4312",
+			cfConnectingIP:      []string{"2001:0db8:0:0::7"},
+			trustCFConnectingIP: true,
+			wantAddress:         "2001:db8::7",
+			wantPeerAddress:     "2001:db8::2",
+			wantSource:          clientIPSourceCFConnectingIP,
+		},
+		{
+			name:                "rejects malformed trusted header",
+			remoteAddr:          "10.0.0.7:4312",
+			cfConnectingIP:      []string{"not-an-ip"},
+			trustCFConnectingIP: true,
+			wantAddress:         "10.0.0.7",
+			wantPeerAddress:     "10.0.0.7",
+			wantSource:          clientIPSourceRemoteAddr,
+		},
+		{
+			name:                "rejects comma-separated trusted header",
+			remoteAddr:          "10.0.0.7:4312",
+			cfConnectingIP:      []string{"198.51.100.44, 203.0.113.9"},
+			trustCFConnectingIP: true,
+			wantAddress:         "10.0.0.7",
+			wantPeerAddress:     "10.0.0.7",
+			wantSource:          clientIPSourceRemoteAddr,
+		},
+		{
+			name:                "rejects duplicate trusted headers",
+			remoteAddr:          "10.0.0.7:4312",
+			cfConnectingIP:      []string{"198.51.100.44", "203.0.113.9"},
+			trustCFConnectingIP: true,
+			wantAddress:         "10.0.0.7",
+			wantPeerAddress:     "10.0.0.7",
+			wantSource:          clientIPSourceRemoteAddr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "http://relay.test/ws", nil)
+			request.RemoteAddr = tt.remoteAddr
+			for _, value := range tt.cfConnectingIP {
+				request.Header.Add(cfConnectingIPHeader, value)
+			}
+
+			got := resolveClientIP(request, tt.trustCFConnectingIP)
+			if got.address != tt.wantAddress {
+				t.Errorf("address = %q, want %q", got.address, tt.wantAddress)
+			}
+			if got.peerAddress != tt.wantPeerAddress {
+				t.Errorf("peerAddress = %q, want %q", got.peerAddress, tt.wantPeerAddress)
+			}
+			if got.source != tt.wantSource {
+				t.Errorf("source = %q, want %q", got.source, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestHandleWebSocketRateLimitsByTrustedCloudflareIP(t *testing.T) {
+	server := &Server{
+		manager:             NewGroupManager(),
+		rateLimiter:         NewRateLimiter(1, 100),
+		trustCFConnectingIP: true,
+	}
+	const clientIP = "198.51.100.44"
+	if !server.rateLimiter.AllowConnection(clientIP) {
+		t.Fatal("failed to occupy the trusted client IP bucket")
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "http://relay.test/ws", nil)
+	request.RemoteAddr = "10.0.0.7:4312"
+	request.Header.Set(cfConnectingIPHeader, clientIP)
+	response := httptest.NewRecorder()
+
+	server.handleWebSocket(response, request)
+
+	if response.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusTooManyRequests)
 	}
 }
 

--- a/internal/relay/ratelimit.go
+++ b/internal/relay/ratelimit.go
@@ -6,9 +6,15 @@ import (
 )
 
 const (
-	defaultMaxPerIP = 10
+	defaultMaxPerIP = 20
 	defaultMaxRooms = 10000
 )
+
+type ConnectionStats struct {
+	ActiveConnections   int64
+	ActiveClientIPs     int
+	MaxConnectionsPerIP int64
+}
 
 type RateLimiter struct {
 	maxPerIP int
@@ -39,6 +45,24 @@ func (rl *RateLimiter) ReleaseConnection(ip string) {
 	if actual, ok := rl.counts.Load(ip); ok {
 		atomic.AddInt64(actual.(*int64), -1)
 	}
+}
+
+func (rl *RateLimiter) ConnectionStats() ConnectionStats {
+	var stats ConnectionStats
+	rl.counts.Range(func(_, value any) bool {
+		count := atomic.LoadInt64(value.(*int64))
+		if count <= 0 {
+			return true
+		}
+
+		stats.ActiveConnections += count
+		stats.ActiveClientIPs++
+		if count > stats.MaxConnectionsPerIP {
+			stats.MaxConnectionsPerIP = count
+		}
+		return true
+	})
+	return stats
 }
 
 func (rl *RateLimiter) AllowGroup(currentGroupCount int) bool {

--- a/internal/relay/ratelimit.go
+++ b/internal/relay/ratelimit.go
@@ -1,9 +1,6 @@
 package relay
 
-import (
-	"sync"
-	"sync/atomic"
-)
+import "sync"
 
 const (
 	defaultMaxPerIP = 20
@@ -14,54 +11,65 @@ type ConnectionStats struct {
 	ActiveConnections   int64
 	ActiveClientIPs     int
 	MaxConnectionsPerIP int64
+	RejectedConnections int64
 }
 
 type RateLimiter struct {
-	maxPerIP int
-	maxRooms int
-	counts   sync.Map
+	maxPerIP            int
+	maxRooms            int
+	mu                  sync.Mutex
+	counts              map[string]int
+	rejectedConnections int64
 }
 
 func NewRateLimiter(maxPerIP, maxRooms int) *RateLimiter {
 	return &RateLimiter{
 		maxPerIP: maxPerIP,
 		maxRooms: maxRooms,
+		counts:   make(map[string]int),
 	}
 }
 
 func (rl *RateLimiter) AllowConnection(ip string) bool {
-	actual, _ := rl.counts.LoadOrStore(ip, new(int64))
-	counter := actual.(*int64)
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
 
-	newVal := atomic.AddInt64(counter, 1)
-	if int(newVal) > rl.maxPerIP {
-		atomic.AddInt64(counter, -1)
+	count := rl.counts[ip]
+	if count >= rl.maxPerIP {
+		rl.rejectedConnections++
 		return false
 	}
+	rl.counts[ip] = count + 1
 	return true
 }
 
 func (rl *RateLimiter) ReleaseConnection(ip string) {
-	if actual, ok := rl.counts.Load(ip); ok {
-		atomic.AddInt64(actual.(*int64), -1)
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	count, ok := rl.counts[ip]
+	if !ok {
+		return
 	}
+	if count <= 1 {
+		delete(rl.counts, ip)
+		return
+	}
+	rl.counts[ip] = count - 1
 }
 
 func (rl *RateLimiter) ConnectionStats() ConnectionStats {
-	var stats ConnectionStats
-	rl.counts.Range(func(_, value any) bool {
-		count := atomic.LoadInt64(value.(*int64))
-		if count <= 0 {
-			return true
-		}
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
 
-		stats.ActiveConnections += count
+	stats := ConnectionStats{RejectedConnections: rl.rejectedConnections}
+	for _, count := range rl.counts {
+		stats.ActiveConnections += int64(count)
 		stats.ActiveClientIPs++
-		if count > stats.MaxConnectionsPerIP {
-			stats.MaxConnectionsPerIP = count
+		if int64(count) > stats.MaxConnectionsPerIP {
+			stats.MaxConnectionsPerIP = int64(count)
 		}
-		return true
-	})
+	}
 	return stats
 }
 

--- a/internal/relay/ratelimit_test.go
+++ b/internal/relay/ratelimit_test.go
@@ -77,3 +77,47 @@ func TestRateLimiter_DifferentIPs_Independent(t *testing.T) {
 		t.Fatal("second IP should be allowed (different IP, independent limit)")
 	}
 }
+
+func TestDefaultPerIPConnectionLimit(t *testing.T) {
+	rl := NewRateLimiter(defaultMaxPerIP, defaultMaxRooms)
+	for i := 0; i < 20; i++ {
+		if !rl.AllowConnection("192.0.2.1") {
+			t.Fatalf("connection %d should be allowed", i+1)
+		}
+	}
+	if rl.AllowConnection("192.0.2.1") {
+		t.Fatal("connection 21 should be denied")
+	}
+}
+
+func TestRateLimiter_ConnectionStats(t *testing.T) {
+	rl := NewRateLimiter(2, 100)
+	for i := 0; i < 2; i++ {
+		if !rl.AllowConnection("192.0.2.1") {
+			t.Fatalf("connection %d for first IP should be allowed", i+1)
+		}
+	}
+	if !rl.AllowConnection("198.51.100.1") {
+		t.Fatal("connection for second IP should be allowed")
+	}
+	if rl.AllowConnection("192.0.2.1") {
+		t.Fatal("connection over the limit should be denied")
+	}
+
+	want := ConnectionStats{ActiveConnections: 3, ActiveClientIPs: 2, MaxConnectionsPerIP: 2}
+	if got := rl.ConnectionStats(); got != want {
+		t.Fatalf("ConnectionStats() = %+v, want %+v", got, want)
+	}
+
+	rl.ReleaseConnection("192.0.2.1")
+	want = ConnectionStats{ActiveConnections: 2, ActiveClientIPs: 2, MaxConnectionsPerIP: 1}
+	if got := rl.ConnectionStats(); got != want {
+		t.Fatalf("ConnectionStats() after first release = %+v, want %+v", got, want)
+	}
+
+	rl.ReleaseConnection("198.51.100.1")
+	want = ConnectionStats{ActiveConnections: 1, ActiveClientIPs: 1, MaxConnectionsPerIP: 1}
+	if got := rl.ConnectionStats(); got != want {
+		t.Fatalf("ConnectionStats() after second release = %+v, want %+v", got, want)
+	}
+}

--- a/internal/relay/ratelimit_test.go
+++ b/internal/relay/ratelimit_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -104,20 +105,83 @@ func TestRateLimiter_ConnectionStats(t *testing.T) {
 		t.Fatal("connection over the limit should be denied")
 	}
 
-	want := ConnectionStats{ActiveConnections: 3, ActiveClientIPs: 2, MaxConnectionsPerIP: 2}
+	want := ConnectionStats{
+		ActiveConnections:   3,
+		ActiveClientIPs:     2,
+		MaxConnectionsPerIP: 2,
+		RejectedConnections: 1,
+	}
 	if got := rl.ConnectionStats(); got != want {
 		t.Fatalf("ConnectionStats() = %+v, want %+v", got, want)
 	}
 
 	rl.ReleaseConnection("192.0.2.1")
-	want = ConnectionStats{ActiveConnections: 2, ActiveClientIPs: 2, MaxConnectionsPerIP: 1}
+	want = ConnectionStats{
+		ActiveConnections:   2,
+		ActiveClientIPs:     2,
+		MaxConnectionsPerIP: 1,
+		RejectedConnections: 1,
+	}
 	if got := rl.ConnectionStats(); got != want {
 		t.Fatalf("ConnectionStats() after first release = %+v, want %+v", got, want)
 	}
 
 	rl.ReleaseConnection("198.51.100.1")
-	want = ConnectionStats{ActiveConnections: 1, ActiveClientIPs: 1, MaxConnectionsPerIP: 1}
+	want = ConnectionStats{
+		ActiveConnections:   1,
+		ActiveClientIPs:     1,
+		MaxConnectionsPerIP: 1,
+		RejectedConnections: 1,
+	}
 	if got := rl.ConnectionStats(); got != want {
 		t.Fatalf("ConnectionStats() after second release = %+v, want %+v", got, want)
+	}
+}
+
+func TestRateLimiter_ReleaseConnectionEvictsInactiveIPBucket(t *testing.T) {
+	rl := NewRateLimiter(2, 100)
+	if !rl.AllowConnection("192.0.2.1") {
+		t.Fatal("connection should be allowed")
+	}
+	rl.ReleaseConnection("192.0.2.1")
+
+	if trackedIPs := len(rl.counts); trackedIPs != 0 {
+		t.Fatalf("tracked IP buckets = %d, want 0", trackedIPs)
+	}
+}
+
+func TestRateLimiter_ConcurrentReleaseAndReconnectPreservesConnection(t *testing.T) {
+	rl := NewRateLimiter(2, 100)
+	const ip = "192.0.2.1"
+	if !rl.AllowConnection(ip) {
+		t.Fatal("initial connection should be allowed")
+	}
+
+	for i := 0; i < 1000; i++ {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		allowed := make(chan bool, 1)
+		go func() {
+			defer wg.Done()
+			rl.ReleaseConnection(ip)
+		}()
+		go func() {
+			defer wg.Done()
+			allowed <- rl.AllowConnection(ip)
+		}()
+		wg.Wait()
+
+		if !<-allowed {
+			t.Fatalf("reconnect %d should be allowed", i+1)
+		}
+		want := ConnectionStats{ActiveConnections: 1, ActiveClientIPs: 1, MaxConnectionsPerIP: 1}
+		if got := rl.ConnectionStats(); got != want {
+			t.Fatalf("ConnectionStats() after reconnect %d = %+v, want %+v", i+1, got, want)
+		}
+	}
+
+	rl.ReleaseConnection(ip)
+	if trackedIPs := len(rl.counts); trackedIPs != 0 {
+		t.Fatalf("tracked IP buckets after final release = %d, want 0", trackedIPs)
 	}
 }

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -10,30 +11,41 @@ import (
 	"github.com/sesori-ai/sesori_relay_server/internal/notifications"
 )
 
+const connectionStatsLogInterval = 10 * time.Minute
+
 // Server is the relay WebSocket server. It manages rooms, rate limiting, and
 // delegates authentication to the provided Authenticator (nil = auth disabled).
 type Server struct {
-	addr            string
-	manager         *GroupManager
-	rateLimiter     *RateLimiter
-	httpServer      *http.Server
-	jwtAuth         *auth.JWTAuthenticator
-	notifications   *notifications.Client
-	requireBridgeID bool
+	addr                string
+	manager             *GroupManager
+	rateLimiter         *RateLimiter
+	httpServer          *http.Server
+	jwtAuth             *auth.JWTAuthenticator
+	notifications       *notifications.Client
+	requireBridgeID     bool
+	trustCFConnectingIP bool
 }
 
 // NewServer creates a relay server. Pass a nil authenticator to disable auth.
 // requireBridgeID enforces that every bridge connection sends a bridgeId in
 // its auth message; when false, bridges without bridgeId are accepted (legacy
 // path) and no bridgeId is forwarded to the auth server.
-func NewServer(addr string, jwtAuth *auth.JWTAuthenticator, notifs *notifications.Client, requireBridgeID bool) *Server {
+// trustCFConnectingIP uses Cloudflare's visitor IP header for rate limiting and
+// must only be enabled when direct access to the origin is blocked.
+func NewServer(
+	addr string,
+	jwtAuth *auth.JWTAuthenticator,
+	notifs *notifications.Client,
+	requireBridgeID, trustCFConnectingIP bool,
+) *Server {
 	return &Server{
-		addr:            addr,
-		manager:         NewGroupManager(),
-		rateLimiter:     NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
-		jwtAuth:         jwtAuth,
-		notifications:   notifs,
-		requireBridgeID: requireBridgeID,
+		addr:                addr,
+		manager:             NewGroupManager(),
+		rateLimiter:         NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
+		jwtAuth:             jwtAuth,
+		notifications:       notifs,
+		requireBridgeID:     requireBridgeID,
+		trustCFConnectingIP: trustCFConnectingIP,
 	}
 }
 
@@ -42,6 +54,10 @@ func (s *Server) Manager() *GroupManager {
 }
 
 func (s *Server) Start(ctx context.Context) error {
+	statsCtx, stopStats := context.WithCancel(ctx)
+	defer stopStats()
+	go s.logConnectionStats(statsCtx)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
 	mux.HandleFunc("GET /status", handleStatus)
@@ -60,6 +76,27 @@ func (s *Server) Start(ctx context.Context) error {
 	}()
 
 	return s.httpServer.ListenAndServe()
+}
+
+func (s *Server) logConnectionStats(ctx context.Context) {
+	ticker := time.NewTicker(connectionStatsLogInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			stats := s.rateLimiter.ConnectionStats()
+			slog.Info(
+				"relay connection stats",
+				"activeConnections", stats.ActiveConnections,
+				"activeClientIPs", stats.ActiveClientIPs,
+				"maxConnectionsPerIP", stats.MaxConnectionsPerIP,
+				"activeGroups", s.manager.Count(),
+			)
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -91,6 +91,7 @@ func (s *Server) logConnectionStats(ctx context.Context) {
 				"activeConnections", stats.ActiveConnections,
 				"activeClientIPs", stats.ActiveClientIPs,
 				"maxConnectionsPerIP", stats.MaxConnectionsPerIP,
+				"rejectedConnections", stats.RejectedConnections,
 				"activeGroups", s.manager.Count(),
 			)
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary

- rate-limit WebSockets by a validated `CF-Connecting-IP` value when Cloudflare trust is explicitly enabled
- raise the per-client concurrent WebSocket cap from 10 to 20
- log aggregate connection statistics every 10 minutes and add debug-only client/peer IP diagnostics
- honor the documented `LOG_LEVEL` environment variable and document production verification
- ignore `.DS_Store`

## Root cause

The relay currently keys its concurrent connection cap from `RemoteAddr`. Behind Cloudflare and DigitalOcean ingress, that is a proxy peer address, so unrelated users can share one 10-connection bucket and receive HTTP 429 responses before WebSocket authentication.

Proxy trust is opt-in because accepting `CF-Connecting-IP` on a directly reachable origin would let clients spoof their rate-limit identity. Production must set `RELAY_TRUST_CF_CONNECTING_IP=true` only while all traffic is guaranteed to pass through Cloudflare.

## Production verification

1. Set `RELAY_TRUST_CF_CONNECTING_IP=true` and temporarily set `LOG_LEVEL=debug`.
2. Connect through Wi-Fi and cellular networks.
3. Confirm `websocket client IP resolved` logs use `source=cf-connecting-ip`, show varying `clientIP` values, and may show a repeated proxy `peerIP`.
4. Confirm periodic `relay connection stats` logs report plausible `activeConnections`, `activeClientIPs`, `maxConnectionsPerIP`, and `activeGroups` values.
5. Restore `LOG_LEVEL=info` after verification because debug logs contain client IP addresses.

## Testing

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/relay`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-client WebSocket rate limiting behind proxies by using a validated `CF-Connecting-IP` when explicitly trusted, preventing unrelated users from sharing one bucket. Raises the per-IP concurrent limit to 20 and adds periodic, bounded connection stats logging.

- **Bug Fixes**
  - Use `CF-Connecting-IP` for rate limiting only when `--trust-cf-connecting-ip`/`RELAY_TRUST_CF_CONNECTING_IP` is enabled; otherwise use `RemoteAddr`.
  - Reject malformed, comma-separated, or duplicate `CF-Connecting-IP` headers; IPv4/IPv6 are canonicalized.

- **New Features**
  - Increase per-client concurrent WebSocket cap from 10 to 20.
  - Log aggregate connection stats every 10 minutes (active connections, active client IPs, busiest IP, rejected attempts, active groups); telemetry is bounded by evicting inactive IP buckets.
  - Honor `LOG_LEVEL`; add `--trust-cf-connecting-ip` flag (and docs); ignore `.DS_Store`.

<sup>Written for commit 90908955a61742f8d9e50f79f4b6df377302f53b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_relay_server/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

