### PR TITLE
feat: require bridge IDs unconditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The relay routes traffic by account — connections are grouped by the `userId` 
 
 ## How it works
 
-1. Bridge CLI connects to `/ws` and sends an auth message with a signed JWT and role `"bridge"`
+1. Bridge CLI connects to `/ws` and sends an auth message with a signed JWT, role `"bridge"`, and its `bridgeId`
 2. Phone connects to `/ws` and sends an auth message with a signed JWT and role `"phone"`
 3. Relay extracts `userId` from each JWT and groups connections by account — 1 bridge + up to 5 phones per account
 4. Binary frames from phone → relay → bridge carry a 2-byte `connId` prefix so the bridge can address replies back to the correct phone
@@ -41,7 +41,6 @@ The server listens on `:8080` by default.
 |------|---------|---------|-------------|
 | `--addr` | `RELAY_ADDR` | `:8080` | Listen address |
 | `--log-level` | `LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
-| `--require-bridge-id` | `RELAY_REQUIRE_BRIDGE_ID` | `false` | Require `bridgeId` field on bridge auth messages. Default `false` accepts legacy bridges (no `bridgeId`) and logs a warning. Set `true` to enforce after the bridge fleet has rolled over. |
 | `--trust-cf-connecting-ip` | `RELAY_TRUST_CF_CONNECTING_IP` | `false` | Use Cloudflare's validated `CF-Connecting-IP` value for per-IP limits. Enable only when every request reaches the relay through Cloudflare and direct origin access is blocked. |
 
 ## Endpoints
@@ -92,10 +91,9 @@ Every client sends this as the first WebSocket message (plaintext JSON):
 Both roles authenticate with the user's **access token** (`tokenType:
 "access"`, `aud: "mobile"`); no other token type is accepted.
 
-The `bridgeId` field is optional for `role: "phone"` (ignored) and is
-optional for `role: "bridge"` unless the relay was started with
-`--require-bridge-id=true` (or `RELAY_REQUIRE_BRIDGE_ID=true`). Format:
-`^br_[A-Za-z0-9_-]{8,32}$`. The relay does not validate the value
+The `bridgeId` field is required for `role: "bridge"` and ignored for
+`role: "phone"`. Its format is `^br_[A-Za-z0-9_-]{8,32}$`. The relay
+does not validate the value
 against any database at handshake time; it forwards it to the auth
 server in the bridge-status report. If the auth server answers that
 report with an explicit HTTP 404 (bridgeId unknown, revoked, or owned

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -23,7 +23,6 @@ func main() {
 	logLevel := flag.String("log-level", "info", "log level (debug, info, warn, error)")
 	authBackendURL := flag.String("auth-backend-url", "", "auth backend base URL (e.g. https://auth.example.com); auth is disabled when empty")
 	relayWebhookSecret := flag.String("relay-webhook-secret", "", "shared secret for auth server webhook")
-	requireBridgeID := flag.Bool("require-bridge-id", false, "require bridgeId field on bridge auth messages (transition gate; set true once the bridge fleet has rolled over)")
 	trustCFConnectingIP := flag.Bool(
 		"trust-cf-connecting-ip",
 		false,
@@ -41,16 +40,6 @@ func main() {
 	if !flagWasSet("log-level") {
 		if value := os.Getenv("LOG_LEVEL"); value != "" {
 			*logLevel = value
-		}
-	}
-	if !flagWasSet("require-bridge-id") {
-		v, ok, err := envBool("RELAY_REQUIRE_BRIDGE_ID")
-		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "invalid RELAY_REQUIRE_BRIDGE_ID: %v\n", err)
-			os.Exit(1)
-		}
-		if ok {
-			*requireBridgeID = v
 		}
 	}
 	if !flagWasSet("trust-cf-connecting-ip") {
@@ -80,7 +69,6 @@ func main() {
 		"starting relay server",
 		"addr", *addr,
 		"log-level", *logLevel,
-		"require-bridge-id", *requireBridgeID,
 		"trust-cf-connecting-ip", *trustCFConnectingIP,
 	)
 
@@ -103,7 +91,7 @@ func main() {
 		slog.Info("push notifications disabled (no webhook secret)")
 	}
 
-	server := relay.NewServer(*addr, authenticator, notifs, *requireBridgeID, *trustCFConnectingIP)
+	server := relay.NewServer(*addr, authenticator, notifs, *trustCFConnectingIP)
 
 	if err := server.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.Error("server error", "err", err)

--- a/internal/notifications/client.go
+++ b/internal/notifications/client.go
@@ -23,7 +23,7 @@ var ErrBridgeNotFound = errors.New("bridge not found")
 
 type BridgeStatusPayload struct {
 	UserID    string `json:"userId"`
-	BridgeID  string `json:"bridgeId,omitempty"`
+	BridgeID  string `json:"bridgeId"`
 	Status    string `json:"status"`
 	Timestamp string `json:"timestamp"`
 }

--- a/internal/notifications/client_test.go
+++ b/internal/notifications/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -54,39 +53,6 @@ func TestClient_NotifyBridgeStatus_Success(t *testing.T) {
 	client := NewClient(ts.URL, secret)
 	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusConnected)
 	if err != nil {
-		t.Fatalf("NotifyBridgeStatus returned error: %v", err)
-	}
-}
-
-func TestClient_NotifyBridgeStatus_LegacyNoBridgeID(t *testing.T) {
-	const secret = "test-secret"
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read payload: %v", err)
-		}
-		if strings.Contains(string(body), "bridgeId") {
-			t.Fatalf("expected payload to omit bridgeId key, got %s", string(body))
-		}
-
-		var payload BridgeStatusPayload
-		if err := json.Unmarshal(body, &payload); err != nil {
-			t.Fatalf("decode payload: %v", err)
-		}
-		if payload.UserID != "user-123" {
-			t.Fatalf("expected userId user-123, got %q", payload.UserID)
-		}
-		if payload.BridgeID != "" {
-			t.Fatalf("expected empty bridgeId in legacy path, got %q", payload.BridgeID)
-		}
-
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	client := NewClient(ts.URL, secret)
-	if err := client.NotifyBridgeStatus(context.Background(), "user-123", "", BridgeStatusConnected); err != nil {
 		t.Fatalf("NotifyBridgeStatus returned error: %v", err)
 	}
 }

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -43,7 +43,7 @@ type RoleAuthMessage struct {
 	Type     string `json:"type"` // "auth"
 	Token    string `json:"token"`
 	Role     string `json:"role"`               // "bridge" or "phone"
-	BridgeID string `json:"bridgeId,omitempty"` // optional; bridge role only. Format: ^br_[A-Za-z0-9_-]{8,32}$. Required when the relay runs with --require-bridge-id.
+	BridgeID string `json:"bridgeId,omitempty"` // required for bridges, ignored for phones. Format: ^br_[A-Za-z0-9_-]{8,32}$.
 }
 
 // PhoneConnectedMessage is sent by relay to bridge when a phone joins.

--- a/internal/relay/account_group_test.go
+++ b/internal/relay/account_group_test.go
@@ -195,10 +195,6 @@ func TestGroupManager_HasLiveBridgeWithID(t *testing.T) {
 	if m.HasLiveBridgeWithID("user1", "br_y") {
 		t.Error("expected false for a different bridge id")
 	}
-	// An empty bridgeId (legacy) is never matched.
-	if m.HasLiveBridgeWithID("user1", "") {
-		t.Error("expected false for an empty bridge id")
-	}
 }
 
 // A stale handler whose cleanup runs late must not delete a fresh group that a

--- a/internal/relay/group_manager.go
+++ b/internal/relay/group_manager.go
@@ -53,12 +53,8 @@ func (m *GroupManager) Count() int {
 // a live bridge with bridgeID. A displaced handler uses this before emitting a
 // stale BridgeStatusDisconnected: if a fresh connection already re-registered
 // the same bridgeId (possibly in a recreated group), the old handler's late
-// teardown must not mark that live bridge offline in the auth server. bridgeID
-// must be non-empty (legacy bridges without an id are never matched).
+// teardown must not mark that live bridge offline in the auth server.
 func (m *GroupManager) HasLiveBridgeWithID(userID, bridgeID string) bool {
-	if bridgeID == "" {
-		return false
-	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	g, ok := m.groups[userID]

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -124,25 +124,23 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 	userID := authResult.UserID
 
+	if authMsg.Role == protocol.RoleBridge {
+		if authMsg.BridgeID == "" {
+			slog.Debug("bridge connection rejected: bridgeId required", "userId", userID)
+			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridgeId required")
+			return
+		}
+		if !bridgeIDRegexp.MatchString(authMsg.BridgeID) {
+			slog.Debug("bridge connection rejected: invalid bridgeId format", "userId", userID, "bridgeId", authMsg.BridgeID)
+			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid bridgeId format")
+			return
+		}
+	}
+
 	group := s.manager.GetOrCreateGroup(userID)
 
 	slog.Debug("connection joined group", "userID", userID, "role", authMsg.Role)
 	if authMsg.Role == protocol.RoleBridge {
-		if authMsg.BridgeID != "" && !bridgeIDRegexp.MatchString(authMsg.BridgeID) {
-			s.manager.RemoveGroupIfEmpty(userID, group)
-			slog.Warn("bridge connection rejected: invalid bridgeId format", "userId", userID, "bridgeId", authMsg.BridgeID)
-			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "invalid bridgeId format")
-			return
-		}
-		if s.requireBridgeID && authMsg.BridgeID == "" {
-			s.manager.RemoveGroupIfEmpty(userID, group)
-			slog.Warn("bridge connection rejected: bridgeId required", "userId", userID)
-			_ = conn.Close(websocket.StatusCode(protocol.CloseAuthFailure), "bridgeId required")
-			return
-		}
-		if authMsg.BridgeID == "" {
-			slog.Warn("legacy bridge without bridgeId; set RELAY_REQUIRE_BRIDGE_ID=true to enforce", "userId", userID)
-		}
 		handleBridge(r.Context(), conn, group, s.manager, userID, authMsg.BridgeID, s.notifications)
 		return
 	}
@@ -270,7 +268,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 			if err == nil {
 				return
 			}
-			if bridgeID != "" && errors.Is(err, notifications.ErrBridgeNotFound) {
+			if errors.Is(err, notifications.ErrBridgeNotFound) {
 				// The auth server explicitly reported this bridgeId as unknown,
 				// revoked, or owned by another user. Close exactly this
 				// connection; unblocking its read loop runs the deferred
@@ -298,7 +296,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 			group.Bridge = nil
 		}
 		group.mu.Unlock()
-		shouldNotifyDisconnected := isCurrent || (bridgeID != "" && bridgeID != currentBridgeID)
+		shouldNotifyDisconnected := isCurrent || bridgeID != currentBridgeID
 
 		// Suppress the disconnect notification if this bridgeId is already live
 		// again on the user's current group: a displaced handler whose teardown

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -29,7 +29,6 @@ type testEnv struct {
 }
 
 type testEnvOpts struct {
-	requireBridgeID     bool
 	notificationsClient *notifications.Client
 	trustCFConnectingIP bool
 }
@@ -64,7 +63,7 @@ func newTestEnv(t *testing.T, opts ...testEnvOpts) *testEnv {
 	}
 
 	jwtAuth := auth.NewJWTAuthenticator(ks)
-	relayServer := NewServer(":0", jwtAuth, o.notificationsClient, o.requireBridgeID, o.trustCFConnectingIP)
+	relayServer := NewServer(":0", jwtAuth, o.notificationsClient, o.trustCFConnectingIP)
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		relayServer.handleWebSocket(w, r)
@@ -772,8 +771,8 @@ func TestHandler_BridgeID_StoredOnConnection(t *testing.T) {
 	}
 }
 
-func TestHandler_BridgeAuth_RequiresBridgeID_PostTransition(t *testing.T) {
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+func TestHandler_BridgeAuth_RequiresBridgeID(t *testing.T) {
+	env := newTestEnv(t)
 
 	bridge := env.connectBridgeNoID(t, "user1")
 	expectClose(t, bridge, websocket.StatusCode(protocol.CloseAuthFailure))
@@ -783,8 +782,8 @@ func TestHandler_BridgeAuth_RequiresBridgeID_PostTransition(t *testing.T) {
 	}
 }
 
-func TestHandler_BridgeAuth_AcceptsBridgeID_PostTransition(t *testing.T) {
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+func TestHandler_BridgeAuth_AcceptsBridgeID(t *testing.T) {
+	env := newTestEnv(t)
 
 	bridge := env.connectBridgeWithID(t, "user1", "br_abc12345")
 	defer bridge.CloseNow()
@@ -795,7 +794,7 @@ func TestHandler_BridgeAuth_AcceptsBridgeID_PostTransition(t *testing.T) {
 }
 
 func TestHandler_BridgeAuth_AcceptsAccessTokenWithBridgeID(t *testing.T) {
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
+	env := newTestEnv(t)
 	ctx := context.Background()
 
 	conn, err := env.dial(ctx)
@@ -815,7 +814,7 @@ func TestHandler_BridgeAuth_AcceptsAccessTokenWithBridgeID(t *testing.T) {
 }
 
 func TestHandler_BridgeAuth_RejectsBridgeTypedToken(t *testing.T) {
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+	env := newTestEnv(t)
 	ctx := context.Background()
 
 	conn, err := env.dial(ctx)
@@ -831,7 +830,7 @@ func TestHandler_BridgeAuth_RejectsBridgeTypedToken(t *testing.T) {
 }
 
 func TestHandler_BridgeAuth_RejectsBridgeTokenWithoutBridgeID(t *testing.T) {
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
+	env := newTestEnv(t)
 	ctx := context.Background()
 
 	conn, err := env.dial(ctx)
@@ -846,33 +845,22 @@ func TestHandler_BridgeAuth_RejectsBridgeTokenWithoutBridgeID(t *testing.T) {
 	expectClose(t, conn, websocket.StatusCode(protocol.CloseAuthFailure))
 }
 
-func TestHandler_BridgeAuth_LegacyAllowedInTransition(t *testing.T) {
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
-
-	bridge := env.connectBridgeNoID(t, "user1")
-	defer bridge.CloseNow()
-
-	if env.relay.manager.Count() != 1 {
-		t.Errorf("expected 1 group (legacy accepted in transition), got %d", env.relay.manager.Count())
-	}
-}
-
 func TestHandler_BridgeAuth_InvalidBridgeID_Format(t *testing.T) {
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: false})
+	env := newTestEnv(t)
 
 	bridge := env.connectBridgeWithID(t, "user1", "not-a-valid-bridge-id")
 	expectClose(t, bridge, websocket.StatusCode(protocol.CloseAuthFailure))
 }
 
-func TestHandler_BridgeAuth_InvalidBridgeID_FormatPostTransition(t *testing.T) {
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+func TestHandler_BridgeAuth_RejectsShortBridgeID(t *testing.T) {
+	env := newTestEnv(t)
 
 	bridge := env.connectBridgeWithID(t, "user1", "br_short")
 	expectClose(t, bridge, websocket.StatusCode(protocol.CloseAuthFailure))
 }
 
 func TestHandler_PhoneAuth_IgnoresStrayBridgeID(t *testing.T) {
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true})
+	env := newTestEnv(t)
 
 	ctx := context.Background()
 	conn, err := env.dial(ctx)
@@ -944,7 +932,7 @@ func TestHandler_NotificationsClient_ForwardsBridgeID(t *testing.T) {
 	t.Cleanup(notifServer.Close)
 
 	notif := notifications.NewClient(notifServer.URL, secret)
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
+	env := newTestEnv(t, testEnvOpts{notificationsClient: notif})
 
 	conn := env.connectBridgeWithID(t, "user1", bridgeID)
 
@@ -1017,7 +1005,7 @@ func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing
 	t.Cleanup(notifServer.Close)
 
 	notif := notifications.NewClient(notifServer.URL, secret)
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
+	env := newTestEnv(t, testEnvOpts{notificationsClient: notif})
 	oldBridge := env.connectBridgeWithID(t, "user1", "br_oldBridge01")
 
 	first := readCaptured("old bridge connected")
@@ -1082,7 +1070,7 @@ func TestHandler_BridgeRevoked_ConnectReport404_ClosesWith4006(t *testing.T) {
 	t.Cleanup(notifServer.Close)
 
 	notif := notifications.NewClient(notifServer.URL, secret)
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
+	env := newTestEnv(t, testEnvOpts{notificationsClient: notif})
 
 	conn := env.connectBridgeWithID(t, "user1", "br_revoked001")
 	defer conn.CloseNow()
@@ -1105,7 +1093,7 @@ func TestHandler_BridgeRevoked_ConnectReport5xx_FailOpen(t *testing.T) {
 	t.Cleanup(notifServer.Close)
 
 	notif := notifications.NewClient(notifServer.URL, "test-relay-secret")
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
+	env := newTestEnv(t, testEnvOpts{notificationsClient: notif})
 
 	conn := env.connectBridgeWithID(t, "user1", "br_abc12345")
 	defer conn.CloseNow()
@@ -1126,7 +1114,7 @@ func TestHandler_BridgeRevoked_ConnectReportTransportError_FailOpen(t *testing.T
 	notifServer.Close()
 
 	notif := notifications.NewClient(unreachableURL, "test-relay-secret")
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: true, notificationsClient: notif})
+	env := newTestEnv(t, testEnvOpts{notificationsClient: notif})
 
 	conn := env.connectBridgeWithID(t, "user1", "br_abc12345")
 	defer conn.CloseNow()
@@ -1135,26 +1123,6 @@ func TestHandler_BridgeRevoked_ConnectReportTransportError_FailOpen(t *testing.T
 
 	if env.relay.manager.Count() != 1 {
 		t.Fatalf("expected bridge to stay connected on transport error, got %d groups", env.relay.manager.Count())
-	}
-	expectOpen(t, conn, 300*time.Millisecond)
-}
-
-func TestHandler_BridgeRevoked_LegacyNoBridgeID_404_FailOpen(t *testing.T) {
-	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	t.Cleanup(notifServer.Close)
-
-	notif := notifications.NewClient(notifServer.URL, "test-relay-secret")
-	env := newTestEnv(t, testEnvOpts{requireBridgeID: false, notificationsClient: notif})
-
-	conn := env.connectBridgeNoID(t, "user1")
-	defer conn.CloseNow()
-
-	time.Sleep(150 * time.Millisecond) // let the async status report complete
-
-	if env.relay.manager.Count() != 1 {
-		t.Fatalf("expected legacy bridge to stay connected, got %d groups", env.relay.manager.Count())
 	}
 	expectOpen(t, conn, 300*time.Millisecond)
 }

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -22,21 +22,17 @@ type Server struct {
 	httpServer          *http.Server
 	jwtAuth             *auth.JWTAuthenticator
 	notifications       *notifications.Client
-	requireBridgeID     bool
 	trustCFConnectingIP bool
 }
 
 // NewServer creates a relay server. Pass a nil authenticator to disable auth.
-// requireBridgeID enforces that every bridge connection sends a bridgeId in
-// its auth message; when false, bridges without bridgeId are accepted (legacy
-// path) and no bridgeId is forwarded to the auth server.
 // trustCFConnectingIP uses Cloudflare's visitor IP header for rate limiting and
 // must only be enabled when direct access to the origin is blocked.
 func NewServer(
 	addr string,
 	jwtAuth *auth.JWTAuthenticator,
 	notifs *notifications.Client,
-	requireBridgeID, trustCFConnectingIP bool,
+	trustCFConnectingIP bool,
 ) *Server {
 	return &Server{
 		addr:                addr,
@@ -44,7 +40,6 @@ func NewServer(
 		rateLimiter:         NewRateLimiter(defaultMaxPerIP, defaultMaxRooms),
 		jwtAuth:             jwtAuth,
 		notifications:       notifs,
-		requireBridgeID:     requireBridgeID,
 		trustCFConnectingIP: trustCFConnectingIP,
 	}
 }


### PR DESCRIPTION
## Summary

- remove the `--require-bridge-id` / `RELAY_REQUIRE_BRIDGE_ID` transition gate and require a valid `bridgeId` on every bridge auth message
- validate bridge IDs before creating account groups and remove legacy empty-ID notification and disconnect paths
- make bridge-ID validation rejections debug-only so reconnecting outdated bridges do not emit warning spam
- update protocol documentation and tests for the permanent requirement

## Operational impact

- `RELAY_REQUIRE_BRIDGE_ID` can be removed from deployments; it is no longer read
- remove any `--require-bridge-id` CLI argument because the flag no longer exists
- outdated bridges without an ID are closed with `CloseAuthFailure`; at the default `LOG_LEVEL=info`, their reconnect loop produces no per-attempt rejection logs
- `LOG_LEVEL=debug` remains intentionally verbose and still records client-IP and bridge rejection diagnostics

## Testing

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require `bridgeId` for all bridge auth and remove the `--require-bridge-id`/`RELAY_REQUIRE_BRIDGE_ID` gate. Missing or invalid IDs close the connection with `CloseAuthFailure`, and rejections log at debug level only.

- **Migration**
  - Remove `RELAY_REQUIRE_BRIDGE_ID` and `--require-bridge-id` from deployments.
  - Ensure all bridges send a valid `bridgeId` (`^br_[A-Za-z0-9_-]{8,32}$`).
  - Legacy bridges without an ID are closed. At `LOG_LEVEL=info`, no per-attempt rejection logs are emitted.

- **Refactors**
  - Validate `bridgeId` before group creation and delete legacy no-ID paths/tests.
  - `internal/notifications` now always includes a non-empty `bridgeId`; `ErrBridgeNotFound` on connect closes the bridge.
  - Remove `requireBridgeID` from `cmd/relay` and the `NewServer` signature; update README and tests accordingly.

<sup>Written for commit 333a33432be251e031b9d0c95ccfb232912e1733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_relay_server/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

