### PR TITLE
⚙️ [macos-darkwake-notifications] Forward wake policy and device observations [step 2/3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ Roles: `"bridge"` or `"phone"`. The relay closes the connection if auth fails.
 | `bridge_connection_observed` | phone → relay | Bounded device UUID proving that exact surface restored E2E connectivity; used only to suppress its pending online push |
 
 These two client controls are plaintext connection metadata. Relay validates and forwards them to auth with an
-in-memory socket correlation ID, but never decrypts or inspects binary session traffic. Missing or invalid metadata
-falls back to normal conservative notification behavior and cannot close or delay transport.
+in-memory socket correlation ID, but never decrypts or inspects binary session traffic. A socket that earned offline
+notification eligibility while normally awake retains it across later sleep suppression; a suppress-only socket stays
+quiet unless a normal/full-wake update promotes it. Missing or invalid metadata falls back to normal conservative
+notification behavior and cannot close or delay transport.
 
 ### Data frames (binary)
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Roles: `"bridge"` or `"phone"`. The relay closes the connection if auth fails.
 | `phone_disconnected` | relay → bridge | A phone left; includes `connId` |
 | `bridge_connected` | relay → phone | The bridge is online |
 | `bridge_disconnected` | relay → phone | The bridge disconnected |
+| `bridge_connection_notification_policy` | bridge → relay | Advisory `normal`, `suppress`, or `conservative` connection-push policy; never changes routing |
+| `bridge_connection_observed` | phone → relay | Bounded device UUID proving that exact surface restored E2E connectivity; used only to suppress its pending online push |
+
+These two client controls are plaintext connection metadata. Relay validates and forwards them to auth with an
+in-memory socket correlation ID, but never decrypts or inspects binary session traffic. Missing or invalid metadata
+falls back to normal conservative notification behavior and cannot close or delay transport.
 
 ### Data frames (binary)
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ These two client controls are plaintext connection metadata. Relay validates and
 in-memory socket correlation ID, but never decrypts or inspects binary session traffic. A socket that earned offline
 notification eligibility while normally awake retains it across later sleep suppression; a suppress-only socket stays
 quiet unless a normal/full-wake update promotes it. Missing or invalid metadata falls back to normal conservative
-notification behavior and cannot close or delay transport.
+notification behavior and cannot close or delay transport. Advisory control reports use one HTTP sender and one
+latest-value pending slot per socket; a slow auth server cannot accumulate per-frame request goroutines or block binary
+routing. In-flight advisory requests end with the socket context. Initial registration validation and disconnected
+status reporting retain their separate existing lifecycle behavior.
 
 ### Data frames (binary)
 

--- a/internal/notifications/client.go
+++ b/internal/notifications/client.go
@@ -22,10 +22,14 @@ const (
 var ErrBridgeNotFound = errors.New("bridge not found")
 
 type BridgeStatusPayload struct {
-	UserID    string `json:"userId"`
-	BridgeID  string `json:"bridgeId"`
-	Status    string `json:"status"`
-	Timestamp string `json:"timestamp"`
+	UserID             string `json:"userId"`
+	BridgeID           string `json:"bridgeId"`
+	Status             string `json:"status"`
+	Timestamp          string `json:"timestamp"`
+	Event              string `json:"event,omitempty"`
+	NotificationPolicy string `json:"notificationPolicy,omitempty"`
+	ConnectionID       string `json:"connectionId,omitempty"`
+	DeviceID           string `json:"deviceId,omitempty"`
 }
 
 type Client struct {
@@ -44,14 +48,11 @@ func NewClient(baseURL string, secret string) *Client {
 	}
 }
 
-func (c *Client) NotifyBridgeStatus(ctx context.Context, userID, bridgeID, status string) error {
-	payload := BridgeStatusPayload{
-		UserID:    userID,
-		BridgeID:  bridgeID,
-		Status:    status,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-	}
+func (c *Client) NotifyBridgeStatus(ctx context.Context, payload BridgeStatusPayload) error {
 
+	if payload.Timestamp == "" {
+		payload.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)

--- a/internal/notifications/client_test.go
+++ b/internal/notifications/client_test.go
@@ -45,13 +45,19 @@ func TestClient_NotifyBridgeStatus_Success(t *testing.T) {
 		if _, err := time.Parse(time.RFC3339, payload.Timestamp); err != nil {
 			t.Fatalf("timestamp not RFC3339: %v", err)
 		}
+		if payload.Event != "notification_policy" || payload.NotificationPolicy != "normal" || payload.ConnectionID != "connection-1" {
+			t.Fatalf("missing bounded policy metadata: %+v", payload)
+		}
 
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
 
 	client := NewClient(ts.URL, secret)
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusConnected)
+	err := client.NotifyBridgeStatus(context.Background(), BridgeStatusPayload{
+		UserID: "user-123", BridgeID: "br_abc12345", Status: BridgeStatusConnected,
+		Event: "notification_policy", NotificationPolicy: "normal", ConnectionID: "connection-1",
+	})
 	if err != nil {
 		t.Fatalf("NotifyBridgeStatus returned error: %v", err)
 	}
@@ -64,7 +70,7 @@ func TestClient_NotifyBridgeStatus_Unauthorized(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(ts.URL, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusConnected)
+	err := client.NotifyBridgeStatus(context.Background(), BridgeStatusPayload{UserID: "user-123", BridgeID: "br_abc12345", Status: BridgeStatusConnected})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -80,7 +86,7 @@ func TestClient_NotifyBridgeStatus_ServerError(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(ts.URL, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusDisconnected)
+	err := client.NotifyBridgeStatus(context.Background(), BridgeStatusPayload{UserID: "user-123", BridgeID: "br_abc12345", Status: BridgeStatusDisconnected})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -99,7 +105,7 @@ func TestClient_NotifyBridgeStatus_NotFound(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(ts.URL, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusConnected)
+	err := client.NotifyBridgeStatus(context.Background(), BridgeStatusPayload{UserID: "user-123", BridgeID: "br_abc12345", Status: BridgeStatusConnected})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -116,7 +122,7 @@ func TestClient_NotifyBridgeStatus_ServerUnreachable(t *testing.T) {
 	ts.Close()
 
 	client := NewClient(url, "secret")
-	err := client.NotifyBridgeStatus(context.Background(), "user-123", "br_abc12345", BridgeStatusConnected)
+	err := client.NotifyBridgeStatus(context.Background(), BridgeStatusPayload{UserID: "user-123", BridgeID: "br_abc12345", Status: BridgeStatusConnected})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -7,14 +7,16 @@ import (
 
 // Message type constants for the wire protocol.
 const (
-	TypeAuth           = "auth"
-	TypeKeyExchange    = "key_exchange"
-	TypeReady          = "ready"
-	TypeRequest        = "request"
-	TypeResponse       = "response"
-	TypeSSESubscribe   = "sse_subscribe"
-	TypeSSEUnsubscribe = "sse_unsubscribe"
-	TypeSSEEvent       = "sse_event"
+	TypeAuth                               = "auth"
+	TypeKeyExchange                        = "key_exchange"
+	TypeReady                              = "ready"
+	TypeRequest                            = "request"
+	TypeResponse                           = "response"
+	TypeSSESubscribe                       = "sse_subscribe"
+	TypeSSEUnsubscribe                     = "sse_unsubscribe"
+	TypeSSEEvent                           = "sse_event"
+	TypeBridgeConnectionNotificationPolicy = "bridge_connection_notification_policy"
+	TypeBridgeConnectionObserved           = "bridge_connection_observed"
 
 	// Control messages sent by relay
 	TypePhoneConnected     = "phone_connected"
@@ -25,6 +27,10 @@ const (
 	// Connection roles
 	RoleBridge = "bridge"
 	RolePhone  = "phone"
+
+	ConnectionNotificationPolicyNormal       = "normal"
+	ConnectionNotificationPolicySuppress     = "suppress"
+	ConnectionNotificationPolicyConservative = "conservative"
 )
 
 // Envelope wraps all messages with a type discriminator
@@ -40,10 +46,21 @@ type KeyExchangeMessage struct {
 
 // RoleAuthMessage - client sends this plaintext as first message after WebSocket connect
 type RoleAuthMessage struct {
-	Type     string `json:"type"` // "auth"
-	Token    string `json:"token"`
-	Role     string `json:"role"`               // "bridge" or "phone"
-	BridgeID string `json:"bridgeId,omitempty"` // required for bridges, ignored for phones. Format: ^br_[A-Za-z0-9_-]{8,32}$.
+	Type                         string `json:"type"` // "auth"
+	Token                        string `json:"token"`
+	Role                         string `json:"role"`               // "bridge" or "phone"
+	BridgeID                     string `json:"bridgeId,omitempty"` // required for bridges, ignored for phones. Format: ^br_[A-Za-z0-9_-]{8,32}$.
+	ConnectionNotificationPolicy string `json:"connectionNotificationPolicy,omitempty"`
+}
+
+type BridgeConnectionNotificationPolicyMessage struct {
+	Type   string `json:"type"`
+	Policy string `json:"policy"`
+}
+
+type BridgeConnectionObservedMessage struct {
+	Type     string `json:"type"`
+	DeviceID string `json:"deviceId"`
 }
 
 // PhoneConnectedMessage is sent by relay to bridge when a phone joins.

--- a/internal/relay/account_group.go
+++ b/internal/relay/account_group.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Connection struct {
-	Conn     *websocket.Conn
-	ConnID   uint16
-	Cancel   context.CancelFunc
-	BridgeID string // empty for phones; populated for bridge connections (per-instance identifier from sesori_auth_server)
+	Conn         *websocket.Conn
+	ConnID       uint16
+	Cancel       context.CancelFunc
+	BridgeID     string // empty for phones; populated for bridge connections (per-instance identifier from sesori_auth_server)
+	ConnectionID string // ephemeral correlation for connection-notification policy only
 }
 
 type AccountGroup struct {
@@ -91,6 +92,21 @@ func (g *AccountGroup) PhoneIfCurrentBridge(bridge *Connection, connID uint16) *
 		return nil
 	}
 	return g.Phones[connID]
+}
+
+func (g *AccountGroup) IsCurrentBridge(bridge *Connection) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.Bridge == bridge
+}
+
+func (g *AccountGroup) BridgeForCurrentPhone(phone *Connection) *Connection {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if phone == nil || g.Phones[phone.ConnID] != phone {
+		return nil
+	}
+	return g.Bridge
 }
 
 // IsEmpty returns true if the group has no bridge and no phone connections.

--- a/internal/relay/control_reports_test.go
+++ b/internal/relay/control_reports_test.go
@@ -1,0 +1,114 @@
+package relay
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sesori-ai/sesori_relay_server/internal/notifications"
+	"github.com/sesori-ai/sesori_relay_server/internal/protocol"
+)
+
+func TestControlReportsCoalesceWithoutBlockingSocketProducer(t *testing.T) {
+	received := make(chan notifications.BridgeStatusPayload, 3)
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload notifications.BridgeStatusPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode report: %v", err)
+		}
+		received <- payload
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer server.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	send := newControlReportSender(ctx, notifications.NewClient(server.URL, "test-secret"))
+	readReport := func() notifications.BridgeStatusPayload {
+		t.Helper()
+		select {
+		case report := <-received:
+			return report
+		case <-time.After(2 * time.Second):
+			t.Fatal("report did not arrive")
+			return notifications.BridgeStatusPayload{}
+		}
+	}
+	send(notifications.BridgeStatusPayload{NotificationPolicy: protocol.ConnectionNotificationPolicyConservative})
+	if first := readReport(); first.NotificationPolicy != protocol.ConnectionNotificationPolicyConservative {
+		t.Fatalf("wrong initial report: %+v", first)
+	}
+	producerDone := make(chan struct{})
+	go func() {
+		for i := 0; i < 10_000; i++ {
+			send(notifications.BridgeStatusPayload{NotificationPolicy: protocol.ConnectionNotificationPolicySuppress})
+		}
+		send(notifications.BridgeStatusPayload{NotificationPolicy: protocol.ConnectionNotificationPolicyNormal})
+		close(producerDone)
+	}()
+	select {
+	case <-producerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("socket producer blocked behind notification HTTP")
+	}
+	select {
+	case unexpected := <-received:
+		t.Fatalf("more than one concurrent HTTP request: %+v", unexpected)
+	default:
+	}
+	close(release)
+	if last := readReport(); last.NotificationPolicy != protocol.ConnectionNotificationPolicyNormal {
+		t.Fatalf("queued report was not the latest policy: %+v", last)
+	}
+}
+
+func TestControlReportRequestEndsWithConnectionContext(t *testing.T) {
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload notifications.BridgeStatusPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode report: %v", err)
+		}
+		close(started)
+		<-r.Context().Done()
+		close(cancelled)
+	}))
+	defer server.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	send := newControlReportSender(ctx, notifications.NewClient(server.URL, "test-secret"))
+	send(notifications.BridgeStatusPayload{Event: "connection_observed"})
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("report did not start")
+	}
+	cancel()
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("report survived connection cancellation")
+	}
+}
+
+func TestDeviceObservationUUIDCase(t *testing.T) {
+	for _, value := range []string{
+		"123e4567-e89b-42d3-a456-426614174000",
+		"123E4567-E89B-42D3-A456-426614174000",
+		"123e4567-E89b-42D3-a456-426614174000",
+	} {
+		if !deviceIDRegexp.MatchString(value) {
+			t.Errorf("rejected valid device UUID: %s", value)
+		}
+	}
+	if deviceIDRegexp.MatchString("not-a-device-id") {
+		t.Fatal("accepted invalid device ID")
+	}
+}

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -42,7 +42,7 @@ type clientIPInfo struct {
 }
 
 var bridgeIDRegexp = regexp.MustCompile(`^br_[A-Za-z0-9_-]{8,32}$`)
-var deviceIDRegexp = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+var deviceIDRegexp = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 
 var (
 	bridgeConnectedJSON, _    = json.Marshal(protocol.BridgeConnectedMessage{Type: protocol.TypeBridgeConnected})
@@ -215,6 +215,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 	group.Bridge = newConn
 	group.mu.Unlock()
 	startPingLoop(connCtx, connCancel, conn)
+	reportControl := newControlReportSender(connCtx, notificationsClient)
 
 	phones := group.AllPhones()
 
@@ -273,10 +274,10 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 
 	if notificationsClient != nil {
 		connectedAt := time.Now().UTC().Format(time.RFC3339Nano)
-		go func() {
+		go func(initialPolicy string) {
 			err := notificationsClient.NotifyBridgeStatus(context.Background(), notifications.BridgeStatusPayload{
 				UserID: userID, BridgeID: bridgeID, Status: notifications.BridgeStatusConnected,
-				Timestamp: connectedAt, NotificationPolicy: policy, ConnectionID: connectionID,
+				Timestamp: connectedAt, NotificationPolicy: initialPolicy, ConnectionID: connectionID,
 			})
 			if err == nil {
 				return
@@ -294,7 +295,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 			// Transport errors, timeouts, and 5xx are fail-open: log and keep
 			// the connection.
 			slog.Warn("failed to notify bridge connected", "error", err, "userId", userID, "bridgeId", bridgeID)
-		}()
+		}(policy)
 	}
 
 	defer func() {
@@ -355,26 +356,18 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 				continue
 			}
 			updatedPolicy := normalizeNotificationPolicy(message.Policy)
-			if updatedPolicy != message.Policy || !group.IsCurrentBridge(newConn) {
+			if !group.IsCurrentBridge(newConn) {
 				continue
 			}
 			policy = updatedPolicy
 			if updatedPolicy != protocol.ConnectionNotificationPolicySuppress {
 				disconnectPolicy = updatedPolicy
 			}
-			if notificationsClient != nil {
-				changedAt := time.Now().UTC().Format(time.RFC3339Nano)
-				go func(capturedPolicy string) {
-					err := notificationsClient.NotifyBridgeStatus(context.Background(), notifications.BridgeStatusPayload{
-						UserID: userID, BridgeID: bridgeID, Status: notifications.BridgeStatusConnected,
-						Timestamp: changedAt, Event: "notification_policy", NotificationPolicy: capturedPolicy,
-						ConnectionID: connectionID,
-					})
-					if err != nil {
-						slog.Warn("failed to update bridge notification policy", "error", err, "userId", userID, "bridgeId", bridgeID)
-					}
-				}(policy)
-			}
+			reportControl(notifications.BridgeStatusPayload{
+				UserID: userID, BridgeID: bridgeID, Status: notifications.BridgeStatusConnected,
+				Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Event: "notification_policy",
+				NotificationPolicy: policy, ConnectionID: connectionID,
+			})
 			continue
 		}
 		if len(data) < 2 {
@@ -443,6 +436,7 @@ func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup,
 	}
 
 	startPingLoop(connCtx, connCancel, conn)
+	reportControl := newControlReportSender(connCtx, notificationsClient)
 
 	if bridgeConn != nil {
 		phoneConnMsg, err := json.Marshal(protocol.PhoneConnectedMessage{Type: protocol.TypePhoneConnected, ConnID: connID})
@@ -489,15 +483,11 @@ func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup,
 			if bridge == nil || bridge.ConnectionID == "" || notificationsClient == nil {
 				continue
 			}
-			observedAt := time.Now().UTC().Format(time.RFC3339Nano)
-			go func(bridgeID, connectionID, deviceID string) {
-				if err := notificationsClient.NotifyBridgeStatus(context.Background(), notifications.BridgeStatusPayload{
-					UserID: userID, BridgeID: bridgeID, Status: notifications.BridgeStatusConnected,
-					Timestamp: observedAt, Event: "connection_observed", ConnectionID: connectionID, DeviceID: deviceID,
-				}); err != nil {
-					slog.Warn("failed to report observed bridge connection", "error", err, "userId", userID, "bridgeId", bridgeID)
-				}
-			}(bridge.BridgeID, bridge.ConnectionID, message.DeviceID)
+			reportControl(notifications.BridgeStatusPayload{
+				UserID: userID, BridgeID: bridge.BridgeID, Status: notifications.BridgeStatusConnected,
+				Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Event: "connection_observed",
+				ConnectionID: bridge.ConnectionID, DeviceID: message.DeviceID,
+			})
 			continue
 		}
 
@@ -512,6 +502,44 @@ func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup,
 		binary.BigEndian.PutUint16(framed[:2], connID)
 		copy(framed[2:], data)
 		_ = bridge.Conn.Write(ctx, websocket.MessageBinary, framed)
+	}
+}
+
+// One sender and one pending latest-value report per socket. The socket read
+// loop is the sole producer, and never waits for HTTP or a free queue slot.
+// Control reports are advisory: even a 404 must not control socket lifetime.
+func newControlReportSender(ctx context.Context, client *notifications.Client) func(notifications.BridgeStatusPayload) {
+	if client == nil {
+		return func(notifications.BridgeStatusPayload) {}
+	}
+	reports := make(chan notifications.BridgeStatusPayload, 1)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case report := <-reports:
+				if ctx.Err() != nil {
+					return
+				}
+				if err := client.NotifyBridgeStatus(ctx, report); err != nil {
+					slog.Warn("failed to report connection notification metadata", "error", err,
+						"userId", report.UserID, "bridgeId", report.BridgeID, "event", report.Event)
+				}
+			}
+		}
+	}()
+	return func(report notifications.BridgeStatusPayload) {
+		select {
+		case reports <- report:
+		default:
+			// Replace an obsolete queued value, not the in-flight HTTP request.
+			select {
+			case <-reports:
+			default:
+			}
+			reports <- report // Single producer: the queue now has room.
+		}
 	}
 }
 

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -203,6 +203,10 @@ func startPingLoop(ctx context.Context, cancel context.CancelFunc, conn *websock
 
 func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID, bridgeID, requestedPolicy string, notificationsClient *notifications.Client) {
 	policy := normalizeNotificationPolicy(requestedPolicy)
+	// Disconnect eligibility belongs to this socket episode. A later sleep
+	// suppression hides DarkWake-only online churn but must not erase offline
+	// eligibility already earned while the socket was normally awake.
+	disconnectPolicy := policy
 	connectionID := newConnectionID()
 	group.mu.Lock()
 	oldBridge := group.Bridge
@@ -329,7 +333,7 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 			go func() {
 				if err := notificationsClient.NotifyBridgeStatus(context.Background(), notifications.BridgeStatusPayload{
 					UserID: userID, BridgeID: bridgeID, Status: notifications.BridgeStatusDisconnected,
-					Timestamp: disconnectedAt, NotificationPolicy: policy, ConnectionID: connectionID,
+					Timestamp: disconnectedAt, NotificationPolicy: disconnectPolicy, ConnectionID: connectionID,
 				}); err != nil {
 					slog.Warn("failed to notify bridge disconnected", "error", err, "userId", userID, "bridgeId", bridgeID)
 				}
@@ -355,6 +359,9 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 				continue
 			}
 			policy = updatedPolicy
+			if updatedPolicy != protocol.ConnectionNotificationPolicySuppress {
+				disconnectPolicy = updatedPolicy
+			}
 			if notificationsClient != nil {
 				changedAt := time.Now().UTC().Format(time.RFC3339Nano)
 				go func(capturedPolicy string) {

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -2,7 +2,9 @@ package relay
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -40,6 +42,7 @@ type clientIPInfo struct {
 }
 
 var bridgeIDRegexp = regexp.MustCompile(`^br_[A-Za-z0-9_-]{8,32}$`)
+var deviceIDRegexp = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 
 var (
 	bridgeConnectedJSON, _    = json.Marshal(protocol.BridgeConnectedMessage{Type: protocol.TypeBridgeConnected})
@@ -141,10 +144,10 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	slog.Debug("connection joined group", "userID", userID, "role", authMsg.Role)
 	if authMsg.Role == protocol.RoleBridge {
-		handleBridge(r.Context(), conn, group, s.manager, userID, authMsg.BridgeID, s.notifications)
+		handleBridge(r.Context(), conn, group, s.manager, userID, authMsg.BridgeID, authMsg.ConnectionNotificationPolicy, s.notifications)
 		return
 	}
-	handlePhone(r.Context(), conn, group, s.manager, userID)
+	handlePhone(r.Context(), conn, group, s.manager, userID, s.notifications)
 }
 
 func readAndValidateAuth(ctx context.Context, conn *websocket.Conn, jwtAuth *auth.JWTAuthenticator) (protocol.RoleAuthMessage, auth.AuthResult, bool) {
@@ -198,11 +201,13 @@ func startPingLoop(ctx context.Context, cancel context.CancelFunc, conn *websock
 	}()
 }
 
-func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID, bridgeID string, notificationsClient *notifications.Client) {
+func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID, bridgeID, requestedPolicy string, notificationsClient *notifications.Client) {
+	policy := normalizeNotificationPolicy(requestedPolicy)
+	connectionID := newConnectionID()
 	group.mu.Lock()
 	oldBridge := group.Bridge
 	connCtx, connCancel := context.WithCancel(ctx)
-	newConn := &Connection{Conn: conn, ConnID: 0, Cancel: connCancel, BridgeID: bridgeID}
+	newConn := &Connection{Conn: conn, ConnID: 0, Cancel: connCancel, BridgeID: bridgeID, ConnectionID: connectionID}
 	group.Bridge = newConn
 	group.mu.Unlock()
 	startPingLoop(connCtx, connCancel, conn)
@@ -263,8 +268,12 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 	}
 
 	if notificationsClient != nil {
+		connectedAt := time.Now().UTC().Format(time.RFC3339Nano)
 		go func() {
-			err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusConnected)
+			err := notificationsClient.NotifyBridgeStatus(context.Background(), notifications.BridgeStatusPayload{
+				UserID: userID, BridgeID: bridgeID, Status: notifications.BridgeStatusConnected,
+				Timestamp: connectedAt, NotificationPolicy: policy, ConnectionID: connectionID,
+			})
 			if err == nil {
 				return
 			}
@@ -316,8 +325,12 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 		}
 
 		if shouldNotifyDisconnected && notificationsClient != nil {
+			disconnectedAt := time.Now().UTC().Format(time.RFC3339Nano)
 			go func() {
-				if err := notificationsClient.NotifyBridgeStatus(context.Background(), userID, bridgeID, notifications.BridgeStatusDisconnected); err != nil {
+				if err := notificationsClient.NotifyBridgeStatus(context.Background(), notifications.BridgeStatusPayload{
+					UserID: userID, BridgeID: bridgeID, Status: notifications.BridgeStatusDisconnected,
+					Timestamp: disconnectedAt, NotificationPolicy: policy, ConnectionID: connectionID,
+				}); err != nil {
 					slog.Warn("failed to notify bridge disconnected", "error", err, "userId", userID, "bridgeId", bridgeID)
 				}
 			}()
@@ -333,6 +346,28 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 			return
 		}
 		if msgType == websocket.MessageText {
+			var message protocol.BridgeConnectionNotificationPolicyMessage
+			if err := json.Unmarshal(data, &message); err != nil || message.Type != protocol.TypeBridgeConnectionNotificationPolicy {
+				continue
+			}
+			updatedPolicy := normalizeNotificationPolicy(message.Policy)
+			if updatedPolicy != message.Policy || !group.IsCurrentBridge(newConn) {
+				continue
+			}
+			policy = updatedPolicy
+			if notificationsClient != nil {
+				changedAt := time.Now().UTC().Format(time.RFC3339Nano)
+				go func(capturedPolicy string) {
+					err := notificationsClient.NotifyBridgeStatus(context.Background(), notifications.BridgeStatusPayload{
+						UserID: userID, BridgeID: bridgeID, Status: notifications.BridgeStatusConnected,
+						Timestamp: changedAt, Event: "notification_policy", NotificationPolicy: capturedPolicy,
+						ConnectionID: connectionID,
+					})
+					if err != nil {
+						slog.Warn("failed to update bridge notification policy", "error", err, "userId", userID, "bridgeId", bridgeID)
+					}
+				}(policy)
+			}
 			continue
 		}
 		if len(data) < 2 {
@@ -369,12 +404,13 @@ func handleBridge(ctx context.Context, conn *websocket.Conn, group *AccountGroup
 	}
 }
 
-func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID string) {
+func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup, manager *GroupManager, userID string, notificationsClient *notifications.Client) {
 	var (
 		connID     uint16
 		bridgeConn *Connection
 		connCtx    context.Context
 		connCancel context.CancelFunc
+		phoneConn  *Connection
 	)
 
 	for {
@@ -391,7 +427,7 @@ func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup,
 		}
 
 		connCtx, connCancel = context.WithCancel(ctx)
-		phoneConn := &Connection{Conn: conn, ConnID: id, Cancel: connCancel}
+		phoneConn = &Connection{Conn: conn, ConnID: id, Cancel: connCancel}
 		group.Phones[id] = phoneConn
 		bridgeConn = group.Bridge
 		connID = id
@@ -438,6 +474,23 @@ func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup,
 			return
 		}
 		if msgType == websocket.MessageText {
+			var message protocol.BridgeConnectionObservedMessage
+			if err := json.Unmarshal(data, &message); err != nil || message.Type != protocol.TypeBridgeConnectionObserved || !deviceIDRegexp.MatchString(message.DeviceID) {
+				continue
+			}
+			bridge := group.BridgeForCurrentPhone(phoneConn)
+			if bridge == nil || bridge.ConnectionID == "" || notificationsClient == nil {
+				continue
+			}
+			observedAt := time.Now().UTC().Format(time.RFC3339Nano)
+			go func(bridgeID, connectionID, deviceID string) {
+				if err := notificationsClient.NotifyBridgeStatus(context.Background(), notifications.BridgeStatusPayload{
+					UserID: userID, BridgeID: bridgeID, Status: notifications.BridgeStatusConnected,
+					Timestamp: observedAt, Event: "connection_observed", ConnectionID: connectionID, DeviceID: deviceID,
+				}); err != nil {
+					slog.Warn("failed to report observed bridge connection", "error", err, "userId", userID, "bridgeId", bridgeID)
+				}
+			}(bridge.BridgeID, bridge.ConnectionID, message.DeviceID)
 			continue
 		}
 
@@ -453,4 +506,22 @@ func handlePhone(ctx context.Context, conn *websocket.Conn, group *AccountGroup,
 		copy(framed[2:], data)
 		_ = bridge.Conn.Write(ctx, websocket.MessageBinary, framed)
 	}
+}
+
+func normalizeNotificationPolicy(policy string) string {
+	switch policy {
+	case protocol.ConnectionNotificationPolicyNormal, protocol.ConnectionNotificationPolicySuppress, protocol.ConnectionNotificationPolicyConservative:
+		return policy
+	default:
+		return protocol.ConnectionNotificationPolicyConservative
+	}
+}
+
+func newConnectionID() string {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		slog.Warn("failed to generate bridge notification connection id", "error", err)
+		return ""
+	}
+	return hex.EncodeToString(value[:])
 }

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -1090,6 +1090,27 @@ func TestHandler_BridgeDisconnectPolicyPreservesAwakeEligibility(t *testing.T) {
 	if promotedDisconnect.policy != protocol.ConnectionNotificationPolicyNormal {
 		t.Fatalf("full-wake promotion did not restore offline eligibility: %+v", promotedDisconnect)
 	}
+
+	fallbackBridgeID := "br_wakeFallback1"
+	fallbackBridge := connect(fallbackBridgeID, protocol.ConnectionNotificationPolicySuppress)
+	readMatching("fallback bridge connected", func(event captured) bool {
+		return event.bridgeID == fallbackBridgeID && event.event == ""
+	})
+	if err := fallbackBridge.Write(context.Background(), websocket.MessageText, []byte(
+		`{"type":"bridge_connection_notification_policy","policy":"future-policy"}`,
+	)); err != nil {
+		t.Fatalf("send unknown policy: %v", err)
+	}
+	readMatching("conservative fallback update", func(event captured) bool {
+		return event.bridgeID == fallbackBridgeID && event.event == "notification_policy" && event.policy == protocol.ConnectionNotificationPolicyConservative
+	})
+	fallbackBridge.CloseNow()
+	fallbackDisconnect := readMatching("fallback bridge disconnect", func(event captured) bool {
+		return event.bridgeID == fallbackBridgeID && event.status == notifications.BridgeStatusDisconnected
+	})
+	if fallbackDisconnect.policy != protocol.ConnectionNotificationPolicyConservative {
+		t.Fatalf("unknown policy preserved prior suppression: %+v", fallbackDisconnect)
+	}
 }
 
 func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing.T) {

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -969,6 +969,129 @@ func TestHandler_NotificationsClient_ForwardsBridgeID(t *testing.T) {
 	}
 }
 
+func TestHandler_BridgeDisconnectPolicyPreservesAwakeEligibility(t *testing.T) {
+	const secret = "test-relay-secret"
+
+	type captured struct {
+		bridgeID string
+		status   string
+		event    string
+		policy   string
+	}
+	capturedCh := make(chan captured, 12)
+	notifServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			BridgeID string `json:"bridgeId"`
+			Status   string `json:"status"`
+			Event    string `json:"event"`
+			Policy   string `json:"notificationPolicy"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		capturedCh <- captured{
+			bridgeID: payload.BridgeID,
+			status:   payload.Status,
+			event:    payload.Event,
+			policy:   payload.Policy,
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(notifServer.Close)
+
+	notif := notifications.NewClient(notifServer.URL, secret)
+	env := newTestEnv(t, testEnvOpts{notificationsClient: notif})
+	readMatching := func(label string, matches func(captured) bool) captured {
+		t.Helper()
+		deadline := time.After(2 * time.Second)
+		for {
+			select {
+			case event := <-capturedCh:
+				if matches(event) {
+					return event
+				}
+			case <-deadline:
+				t.Fatalf("timed out waiting for %s", label)
+				return captured{}
+			}
+		}
+	}
+	connect := func(bridgeID, policy string) *websocket.Conn {
+		t.Helper()
+		ctx := context.Background()
+		conn, err := env.dial(ctx)
+		if err != nil {
+			t.Fatalf("dial bridge: %v", err)
+		}
+		message := fmt.Sprintf(
+			`{"type":"auth","token":"%s","role":"bridge","bridgeId":%q,"connectionNotificationPolicy":%q}`,
+			env.makeAccessToken("user1"),
+			bridgeID,
+			policy,
+		)
+		if err := conn.Write(ctx, websocket.MessageText, []byte(message)); err != nil {
+			conn.CloseNow()
+			t.Fatalf("send auth: %v", err)
+		}
+		return conn
+	}
+
+	awakeBridgeID := "br_awakePolicy01"
+	awakeBridge := connect(awakeBridgeID, protocol.ConnectionNotificationPolicyNormal)
+	readMatching("awake connected", func(event captured) bool {
+		return event.bridgeID == awakeBridgeID && event.status == notifications.BridgeStatusConnected && event.event == ""
+	})
+	if err := awakeBridge.Write(context.Background(), websocket.MessageText, []byte(
+		`{"type":"bridge_connection_notification_policy","policy":"suppress"}`,
+	)); err != nil {
+		t.Fatalf("send suppress policy: %v", err)
+	}
+	readMatching("awake suppress update", func(event captured) bool {
+		return event.bridgeID == awakeBridgeID && event.event == "notification_policy" && event.policy == protocol.ConnectionNotificationPolicySuppress
+	})
+	awakeBridge.CloseNow()
+	awakeDisconnect := readMatching("awake disconnect", func(event captured) bool {
+		return event.bridgeID == awakeBridgeID && event.status == notifications.BridgeStatusDisconnected
+	})
+	if awakeDisconnect.policy != protocol.ConnectionNotificationPolicyNormal {
+		t.Fatalf("awake connection lost offline eligibility: %+v", awakeDisconnect)
+	}
+
+	darkWakeBridgeID := "br_darkWakeOnly1"
+	darkWakeBridge := connect(darkWakeBridgeID, protocol.ConnectionNotificationPolicySuppress)
+	readMatching("DarkWake connected", func(event captured) bool {
+		return event.bridgeID == darkWakeBridgeID && event.status == notifications.BridgeStatusConnected
+	})
+	darkWakeBridge.CloseNow()
+	darkWakeDisconnect := readMatching("DarkWake disconnect", func(event captured) bool {
+		return event.bridgeID == darkWakeBridgeID && event.status == notifications.BridgeStatusDisconnected
+	})
+	if darkWakeDisconnect.policy != protocol.ConnectionNotificationPolicySuppress {
+		t.Fatalf("DarkWake-only connection became offline-eligible: %+v", darkWakeDisconnect)
+	}
+
+	promotedBridgeID := "br_wakePromoted1"
+	promotedBridge := connect(promotedBridgeID, protocol.ConnectionNotificationPolicySuppress)
+	readMatching("promoted bridge connected", func(event captured) bool {
+		return event.bridgeID == promotedBridgeID && event.status == notifications.BridgeStatusConnected && event.event == ""
+	})
+	if err := promotedBridge.Write(context.Background(), websocket.MessageText, []byte(
+		`{"type":"bridge_connection_notification_policy","policy":"normal"}`,
+	)); err != nil {
+		t.Fatalf("send normal policy: %v", err)
+	}
+	readMatching("full-wake policy update", func(event captured) bool {
+		return event.bridgeID == promotedBridgeID && event.event == "notification_policy" && event.policy == protocol.ConnectionNotificationPolicyNormal
+	})
+	promotedBridge.CloseNow()
+	promotedDisconnect := readMatching("promoted bridge disconnect", func(event captured) bool {
+		return event.bridgeID == promotedBridgeID && event.status == notifications.BridgeStatusDisconnected
+	})
+	if promotedDisconnect.policy != protocol.ConnectionNotificationPolicyNormal {
+		t.Fatalf("full-wake promotion did not restore offline eligibility: %+v", promotedDisconnect)
+	}
+}
+
 func TestHandler_BridgeReplacement_MarksDistinctOldBridgeDisconnected(t *testing.T) {
 	const secret = "test-relay-secret"
 


### PR DESCRIPTION
## Complexity
⚙️ Moderate — adds connection-scoped control metadata and reporting without changing encrypted traffic routing.

## What
- Forward the bridge's initial notification policy and same-socket policy updates to auth.
- Forward exact-connection, per-device observation receipts from mobile.
- Preserve offline eligibility for an awake connection that subsequently goes to sleep; keep a DarkWake-only connection quiet unless it is promoted by a full wake.
- Preserve live availability broadcasts, socket behavior, and opaque encrypted payload routing.

## Why
A bridge may reconnect during a brief macOS maintenance wake. Filtering pushes must not block that connection, and full wake must lift suppression even when the same socket stays connected.

## Risk and test focus
Medium: control-frame validation, current-connection ownership, mixed-version behavior, and normal-sleep versus DarkWake-only disconnect reporting. Reports remain bounded by the existing five-second HTTP timeout and never gate relay traffic.

## Expected result
Auth receives enough metadata to filter only connection-status notifications. Live clients may still briefly show the bridge online during DarkWake; this is an accepted tradeoff. No database or encryption changes. No change to reconnect, ping, request, or session handling.

## Verification
- `go test ./...` — 71 tests across five packages.
- `go vet ./...`
- Tests cover retained awake-disconnect eligibility, quiet DarkWake-only connections, and same-socket full-wake promotion.
- `git diff --check`

Real macOS sleep cycles and external push delivery were not exercised. This PR does not deploy anything.

## Rollout
Deploy **auth → relay → bridge/mobile**. Deploy the auth companion before enabling the new relay metadata.

1. Auth: https://github.com/sesori-ai/sesori_auth_server/pull/90
2. Relay: https://github.com/sesori-ai/sesori_relay_server/pull/11
3. Bridge/mobile: https://github.com/sesori-ai/sesori_apps_monorepo/pull/1451
